### PR TITLE
Add snyk

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -128,6 +128,14 @@
   percent_increase:  87%
   pricing_source: https://slack.com/pricing
   updated_at: 2018-10-17
+  
+- name: Snyk
+  url: https://snyk.io
+  base_pricing: $23.96 per u/m 
+  sso_pricing: $39.98 per u/m
+  percent_increase: 67%
+  pricing_source: https://snyk.io/plans
+  updated_at: 2018-10-22
 
 - name: SumoLogic
   url: https://www.sumologic.com


### PR DESCRIPTION
Shaming Snyk with a painful 67% price increase for SSO, making it out of reach for smaller businesses and startups wanting to practice good security.