### PR TITLE
Update Stack Overflow's listing

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -240,11 +240,11 @@
 
 - name: Stack Overflow
   url: https://stackoverflow.com
-  base_pricing: $10 per u/m
-  sso_pricing: Call Us!
-  percent_increase: ???
+  base_pricing: $5 per u/m
+  sso_pricing: $11 per u/m
+  percent_increase: 120%
   pricing_source: https://stackoverflow.com/pricing
-  updated_at: 2018-11-26
+  updated_at: 2016-06-24
 
 - name: SumoLogic
   url: https://www.sumologic.com

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -244,7 +244,7 @@
   sso_pricing: $11 per u/m
   percent_increase: 120%
   pricing_source: https://stackoverflow.com/pricing
-  updated_at: 2016-06-24
+  updated_at: 2019-06-24
 
 - name: SumoLogic
   url: https://www.sumologic.com


### PR DESCRIPTION
It looks like they changed their pricing at some point. The base version is now $5, the cheapest version w/ SSO is $11.