### PR TITLE
Remove dialpad

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -47,14 +47,6 @@
   pricing_source: https://databricks.com/product/aws-pricing
   updated_at: 2018-10-22
 
-- name: Dialpad
-  url: https://www.dialpad.com
-  base_pricing: $15 per u/m
-  sso_pricing: $35 per u/m
-  percent_increase:  133%
-  pricing_source: https://www.dialpad.com/pricing
-  updated_at: 2018-10-22
-
 - name: DocuSign
   url: https://www.docusign.com
   base_pricing: $25 per u/m


### PR DESCRIPTION
Removing Dialpad per an e-mail from a user. The pricing was outdated, and all of their plans offer some form of SSO; but SAML isn't supported until the highest tier. It's not ideal but the nuance is hard to reflect in this format so it seems fairer to remove them from the list for now.