### PR TITLE
Remove Checkly.

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -31,14 +31,6 @@
   pricing_source: https://www.box.com/pricing
   updated_at: 2018-10-17
 
-- name: Checkly
-  url: https://checklyhq.com/
-  base_pricing: $29 per month
-  sso_pricing: $199 per month
-  percent_increase: 586%
-  pricing_source: https://checklyhq.com/pricing/
-  updated_at: 2019-07-30
-
 - name: CloudSploit
   url: https://cloudsploit.com
   base_pricing: $36 pcm


### PR DESCRIPTION
For the same reasons Dialpad was [removed](https://github.com/robchahin/sso-wall-of-shame/commit/cd226d37b4b3486d4562be3aa4256f29ad4b74ca), Checkly should also be removed. SSO is offered at all tiers, but only the enterprise tier has SAML.