### PR TITLE
Update to remove Zendesk Support, SSO is now included with all plans

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -340,11 +340,3 @@
   percent_increase: 100%
   pricing_source: https://zapier.com/app/billing/plans/
   updated_at: 2019-10-19
-
-- name: Zendesk Support
-  url: https://www.zendesk.com/support/
-  base_pricing: $19 per u/m
-  sso_pricing: $49 per u/m
-  percent_increase: 157%
-  pricing_source: https://www.zendesk.com/support/compare/
-  updated_at: 2018-10-19


### PR DESCRIPTION
Proposing to remove Zendesk from this document as we just made SSO inclusive on all plans. More information at https://support.zendesk.com/hc/en-us/articles/360037530914-Announcing-enhanced-product-security-features-for-all-plan-levels.