### PR TITLE
Remove GitLab on-prem

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -123,15 +123,6 @@
   pricing_source: https://about.gitlab.com/pricing
   updated_at: 2018-10-21
 
-- name: GitLab On-Prem
-  url: https://about.gitlab.com
-  base_pricing: $4 per u/m
-  sso_pricing: $4 per u/m[^gitlab-price]
-  footnotes: '[^gitlab-price]: On-prem includes "site-wide SSO" in its basic tier which provides many of the core benefits of SSO, with additional SSO options in the next tier up.'
-  percent_increase: 0% 🎉
-  pricing_source: https://about.gitlab.com/pricing
-  updated_at: 2018-10-22
-
 - name: Hubspot Marketing
   url: https://www.hubspot.com
   base_pricing: $46 per month

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -118,7 +118,8 @@
 - name: GitLab Hosted
   url: https://about.gitlab.com
   base_pricing: $4 per u/m
-  sso_pricing: $19 per u/m
+  sso_pricing: $19 per u/m[^gitlab-onprem]
+  footnotes: "[^gitlab-onprem]GitLab's on premise solution offers LDAP auth and sync for every tier."
   percent_increase: 375%
   pricing_source: https://about.gitlab.com/pricing
   updated_at: 2018-10-21


### PR DESCRIPTION
Since SSO appears to be included as a basic feature for the on-prem version of GitLab, it doesn't seem like it belongs on this list.  Additionally, according the the GitLab feature list, it's not actually SSO but ldap sync and auth.  Which does accomplish some of the same goals but does not provide the same user experience as true SSO.