### PR TITLE
Update vendors.yml for BrowserStack

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -33,6 +33,14 @@
   pricing_source: https://www.box.com/pricing
   updated_at: 2018-10-17
 
+- name: BrowserStack
+  url: https://www.browserstack.com/
+  base_pricing: $129 per 5u/m
+  sso_pricing: Call Us!
+  percent_increase: 1.5x to 2x 
+  pricing_source: https://www.browserstack.com/accounts/subscriptions
+  updated_at: 2020-03-05
+
 - name: Checkly
   url: https://checklyhq.com/
   base_pricing: $29 per month


### PR DESCRIPTION
per the email from Browserstack: 

"the SSO feature is an Enterprise offering and the Enterprise plan have a threshold of 10 parallels. This means it is only offered above 10 parallel plans and is ~1.5x to 2x more expensive than the standard pricing model."