### PR TITLE
Update GitHub base pricing

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -119,7 +119,7 @@
   url: https://www.github.com
   base_pricing: $4 per u/m
   sso_pricing: $21 per u/m
-  percent_increase: 525%
+  percent_increase: 425%
   pricing_source: https://github.com/pricing
   updated_at: 2020-04-14
 

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -117,11 +117,11 @@
 
 - name: GitHub
   url: https://www.github.com
-  base_pricing: $9 per u/m
+  base_pricing: $4 per u/m
   sso_pricing: $21 per u/m
-  percent_increase: 133%
+  percent_increase: 525%
   pricing_source: https://github.com/pricing
-  updated_at: 2018-10-19
+  updated_at: 2020-04-14
 
 - name: GitLab Hosted
   url: https://about.gitlab.com


### PR DESCRIPTION
GitHub made a pricing change today, but unfortunately they didn't change how SAML is offered. So it's still part of Enterprise (now available self-serve for $21/u/m). This makes the percent increase 525%!

https://github.blog/2020-04-14-github-is-now-free-for-teams/