### PR TITLE
Update GitHub base user price

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -117,11 +117,11 @@
 
 - name: GitHub
   url: https://www.github.com
-  base_pricing: $9 per u/m
+  base_pricing: $4 per u/m
   sso_pricing: $21 per u/m
-  percent_increase: 133%
+  percent_increase: 425%
   pricing_source: https://github.com/pricing
-  updated_at: 2018-10-19
+  updated_at: 2020-04-14
 
 - name: GitLab Hosted
   url: https://about.gitlab.com


### PR DESCRIPTION
GitHub decreased their "Team" user price to $4.

However note, "All of the core GitHub features are now free for everyone."
So I'm not sure if you additionally just want to bring the _base_ price all the way down to $0.

See blog post: https://github.blog/2020-04-14-github-is-now-free-for-teams/