### PR TITLE
remove customer.io, SSO is now available for all accounts

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -66,14 +66,6 @@
   pricing_source: https://coderpad.io/pricing
   updated_at: 2019-06-28
 
-- name: Customer.io
-  url: https://customer.io/
-  base_pricing: $150 per month
-  sso_pricing: $995 per month
-  percent_increase: 463%
-  pricing_source: https://customer.io/pricing
-  updated_at: 2020-05-09
-
 - name: Databricks
   url: https://databricks.com
   base_pricing: $0.20 per DBU


### PR DESCRIPTION
Hey @robchahin! Joe from Customer.io's Site Reliability team here. Great project and thanks for taking the time to maintain this listing. Our team recently made the decision to remove the "premium" requirement on our SSO features and have made SSO available to all subscribers regardless of plan pricing. Here's a recent diff of [our documentation](https://customer.io/docs/login-with-sso) where we've removed the "you must be this premium to ride this ride" callout:
![image](https://user-images.githubusercontent.com/6409227/81961412-30530880-95c7-11ea-9690-6c19f57c8ac0.png)

Previously when SSO was a Premium only feature our product team would enable it for any account that wrote in requesting it, but we realized this hurt overall discoverability/adoption of a core security feature so we've reversed course and turned SSO on by default for all accounts.

I believe this PR is sufficient to reverse https://github.com/robchahin/sso-wall-of-shame/pull/130

If you have any questions happy to chime in here, cheers!
