### PR TITLE
Updated vendors, added redash.io

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -384,3 +384,11 @@
   percent_increase: 100%
   pricing_source: https://zapier.com/app/billing/plans/
   updated_at: 2019-10-19
+  
+- name: Redash
+  url: https://redash.io/
+  base_pricing: $49 per month, unlimited users
+  sso_pricing: $450 per month, unlimited users
+  percent_increase: ~900%
+  pricing_source: https://redash.io/pricing/
+  updated_at: 2020-07-09


### PR DESCRIPTION
redash.io is a query editor for many types of data sources, and while they do offer a [self-hosted solution that allows SSO for free](https://redash.io/help/open-source/setup#Google-OAuth-Setup), their SaaS option has a 900% markup to enable SSO, as found in their "Business" plan.