### PR TITLE
Removing Databricks from the sso.tax list

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -75,14 +75,6 @@
   pricing_source: https://coderpad.io/pricing
   updated_at: 2019-06-28
 
-- name: Databricks
-  url: https://databricks.com
-  base_pricing: $0.20 per DBU
-  sso_pricing: $0.35 per DBU
-  percent_increase: 75%
-  pricing_source: https://databricks.com/product/aws-pricing
-  updated_at: 2018-10-22
-
 - name: DocuSign
   url: https://www.docusign.com
   base_pricing: $25 per u/m

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -284,14 +284,6 @@
   updated_at: 2019-10-10
   footnotes: "[^raygun]: From their SSO tooltip: 'Basic SSO covers social SSO providers only (e.g. Facebook), Advanced SSO includes SAML2 providers (including ActiveDirectory, Auth0, Okta and OneLogin)'"
 
-- name: Redash
-  url: https://redash.io/
-  base_pricing: $49 per month
-  sso_pricing: $450 per month
-  percent_increase: 818%
-  pricing_source: https://redash.io/pricing/
-  updated_at: 2021-02-12
-
 - name: RingCentral
   url: https://www.ringcentral.com
   base_pricing: $25 per u/m


### PR DESCRIPTION
wDatabricks currently offers the ability for any customer to configure their own SAML SSO provider, with OIDC support coming soon.

There is no additional charge for doing this. See that the "SSO" option is default on all pricing tiers here:
https://databricks.com/product/aws-pricing
