### PR TITLE
Adding BrowserStack

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -61,9 +61,9 @@
 
  name: BrowserStack
   url: https://www.browserstack.com
-  base_pricing: $25 per u/m
-  sso_pricing: $33.52 per u/m
-  percent_increase: 200%
+  base_pricing: $150 per month[^5 users]
+  sso_pricing: $402.24 per month[^5 users]
+  percent_increase: 268%
   pricing_source: https://www.browserstack.com/pricing
   updated_at: 2021-10-29
 

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -59,6 +59,14 @@
   pricing_source: https://www.box.com/pricing
   updated_at: 2018-10-17
 
+ name: BrowserStack
+  url: https://www.browserstack.com
+  base_pricing: $25 per u/m
+  sso_pricing: $33.52 per u/m
+  percent_increase: 200%
+  pricing_source: https://www.browserstack.com/pricing
+  updated_at: 2021-10-29
+
 - name: Canva
   url: https://canva.com/
   base_pricing: $7.77 per u/m


### PR DESCRIPTION
The minimum threshold to start with BrowserStack enterprise plans is 25 users.

The pricing for the enterprise 25 users plan is $10,056 Billed Annually.

5 User Team plan costs $1,500 annually.