### PR TITLE
Add docker

### DIFF
--- a/_vendors/docker.yaml
+++ b/_vendors/docker.yaml
@@ -5,4 +5,4 @@ percent_increase: 200%
 pricing_source: https://www.docker.com/pricing
 sso_pricing: $21 per u/m
 updated_at: 2021-01-26
-url: https://www.docker.com/
+vendor_url: https://www.docker.com/

--- a/_vendors/docker.yaml
+++ b/_vendors/docker.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $7 per u/m
+name: Docker
+percent_increase: 200%
+pricing_source: https://www.docker.com/pricing
+sso_pricing: $21 per u/m
+updated_at: 2021-01-26
+url: https://www.docker.com/


### PR DESCRIPTION
The grace period for Docker Desktop expires January 31, 2022 and SSO is only included in the highest pricing tier.