### PR TITLE
Add Amazon AWS Cognito

### DIFF
--- a/_vendors/amazoncognito.yaml
+++ b/_vendors/amazoncognito.yaml
@@ -1,0 +1,11 @@
+---
+base_pricing: $0.0055 per active user
+footnotes: '[^cognito-price]: The free usage tier includes 50,000 free non-SSO users
+  and only 50 free SSO users.  Between 50 and 50,000 monthly active users, the price
+  increase is infinite.
+name: Amazon AWS (Cognito)
+percent_increase: 172%
+pricing_source: https://aws.amazon.com/cognito/pricing/
+sso_pricing: $0.015 per active user
+updated_at: 2022-02-07
+url: https://aws.amazon.com/cognito/


### PR DESCRIPTION
Added Amazon Cognito, an identity provider for AWS and apps built upon it.

For small sites, they are one of the more punitive increases in price, going from 50,000 free monthly users for non-SSO to 50 free monthly users for SSO, then more than doubling the price on top of that.