### PR TITLE
Add Grammarly

### DIFF
--- a/_vendors/grammarly.yaml
+++ b/_vendors/grammarly.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $12 per u/m
+name: Grammarly
+percent_increase: 5208.33%
+pricing_source: https://www.grammarly.com/plans
+sso_pricing: $625/month
+updated_at: 2022-03-07
+url: https://www.grammarly.com/

--- a/_vendors/grammarly.yaml
+++ b/_vendors/grammarly.yaml
@@ -1,8 +1,10 @@
 ---
 base_pricing: $12 per u/m
 name: Grammarly
-percent_increase: 5208.33%
+percent_increase: 942%[^grammarly-percentage]
 pricing_source: https://www.grammarly.com/plans
-sso_pricing: $625/month
+sso_pricing: $12.50 per u/m, 50 seat minimum
 updated_at: 2022-03-07
-url: https://www.grammarly.com/
+vendor_url: https://www.grammarly.com/
+footnotes: '[^grammarly-percentage]: SSO pricing requires a minimum of 50 users.
+  Percentage increase is calculated assuming a team of 5.'


### PR DESCRIPTION
Grammarly's business plans start at $12.5/month, however require 50 or more users for SSO. This results in a price hike of over 5200%!