### PR TITLE
Rename url parameter to vendor_url

### DIFF
--- a/_vendors/airtable.yaml
+++ b/_vendors/airtable.yaml
@@ -7,4 +7,4 @@ pricing_note: Quote
 pricing_source: https://airtable.com/pricing
 sso_pricing: $60 per u/m
 updated_at: 2019-10-19
-url: https://airtable.com
+vendor_url: https://airtable.com

--- a/_vendors/aqua.yaml
+++ b/_vendors/aqua.yaml
@@ -5,4 +5,4 @@ percent_increase: 147%
 pricing_source: https://aquasec.com/pricing/
 sso_pricing: $2099 per month
 updated_at: 2021-09-06
-url: https://aquasec.com
+vendor_url: https://aquasec.com

--- a/_vendors/asana.yaml
+++ b/_vendors/asana.yaml
@@ -8,4 +8,4 @@ pricing_note: Quote
 pricing_source: https://asana.com/pricing
 sso_pricing: $60 per u/m[^asana-price]
 updated_at: 2020-12-09
-url: https://asana.com
+vendor_url: https://asana.com

--- a/_vendors/atlassianjiracloud.yaml
+++ b/_vendors/atlassianjiracloud.yaml
@@ -9,4 +9,4 @@ percent_increase: 42%
 pricing_source: https://www.atlassian.com/software/jira/pricing
 sso_pricing: $10 per u/m[^jira-price]
 updated_at: 2018-10-22
-url: https://www.atlassian.com
+vendor_url: https://www.atlassian.com

--- a/_vendors/bitrise.yaml
+++ b/_vendors/bitrise.yaml
@@ -5,4 +5,4 @@ percent_increase: 200%
 pricing_source: https://www.bitrise.io/pricing/teams
 sso_pricing: $270
 updated_at: 2019-06-25
-url: https://www.bitrise.io
+vendor_url: https://www.bitrise.io

--- a/_vendors/bitwarden.yaml
+++ b/_vendors/bitwarden.yaml
@@ -5,4 +5,4 @@ percent_increase: 67%
 pricing_source: https://bitwarden.com/pricing/business
 sso_pricing: $5 per u/m
 updated_at: 2021-09-06
-url: https://bitwarden.com
+vendor_url: https://bitwarden.com

--- a/_vendors/box.yaml
+++ b/_vendors/box.yaml
@@ -5,4 +5,4 @@ percent_increase: 200%
 pricing_source: https://www.box.com/pricing
 sso_pricing: $15 per u/m
 updated_at: 2018-10-17
-url: https://www.box.com
+vendor_url: https://www.box.com

--- a/_vendors/canva.yaml
+++ b/_vendors/canva.yaml
@@ -5,4 +5,4 @@ percent_increase: 286%
 pricing_source: https://www.canva.com/pricing/
 sso_pricing: $30 per u/m
 updated_at: 2020-11-24
-url: https://canva.com/
+vendor_url: https://canva.com/

--- a/_vendors/clockify.yaml
+++ b/_vendors/clockify.yaml
@@ -5,4 +5,4 @@ percent_increase: 300%
 pricing_source: https://clockify.me/extra-features
 sso_pricing: $11.99 per u/m
 updated_at: 2021-03-17
-url: https://clockify.me
+vendor_url: https://clockify.me

--- a/_vendors/coppercrm.yaml
+++ b/_vendors/coppercrm.yaml
@@ -5,4 +5,4 @@ percent_increase: 143%
 pricing_source: https://copper.com/pricing
 sso_pricing: $119 per u/m
 updated_at: 2019-07-31
-url: https://copper.com
+vendor_url: https://copper.com

--- a/_vendors/docusign.yaml
+++ b/_vendors/docusign.yaml
@@ -6,4 +6,4 @@ pricing_note: Quote
 pricing_source: https://www.docusign.com/products-and-pricing
 sso_pricing: $50 per u/m
 updated_at: 2018-10-17
-url: https://www.docusign.com
+vendor_url: https://www.docusign.com

--- a/_vendors/dropbox.yaml
+++ b/_vendors/dropbox.yaml
@@ -5,4 +5,4 @@ percent_increase: 67%
 pricing_source: https://www.dropbox.com/business/pricing
 sso_pricing: $25 per u/m
 updated_at: 2018-10-17
-url: https://www.dropbox.com
+vendor_url: https://www.dropbox.com

--- a/_vendors/elastic.yaml
+++ b/_vendors/elastic.yaml
@@ -7,4 +7,4 @@ percent_increase: 15%
 pricing_source: https://www.elastic.co/subscriptions
 sso_pricing: $0.3429
 updated_at: 2021-02-12
-url: https://elastic.co
+vendor_url: https://elastic.co

--- a/_vendors/envoy.yaml
+++ b/_vendors/envoy.yaml
@@ -5,4 +5,4 @@ percent_increase: 202%
 pricing_source: https://envoy.com/pricing/
 sso_pricing: $299 per location/m
 updated_at: 2020-02-17
-url: https://envoy.com
+vendor_url: https://envoy.com

--- a/_vendors/expensify.yaml
+++ b/_vendors/expensify.yaml
@@ -5,4 +5,4 @@ percent_increase: 80%
 pricing_source: https://www.expensify.com/pricing#features
 sso_pricing: $9 per u/m
 updated_at: 2018-10-17
-url: https://www.expensify.com
+vendor_url: https://www.expensify.com

--- a/_vendors/figma.yaml
+++ b/_vendors/figma.yaml
@@ -5,4 +5,4 @@ percent_increase: 275%
 pricing_source: https://www.figma.com/pricing
 sso_pricing: $45 per u/m
 updated_at: 2019-10-19
-url: https://www.figma.com
+vendor_url: https://www.figma.com

--- a/_vendors/github.yaml
+++ b/_vendors/github.yaml
@@ -5,4 +5,4 @@ percent_increase: 425%
 pricing_source: https://github.com/pricing
 sso_pricing: $21 per u/m
 updated_at: 2020-04-14
-url: https://www.github.com
+vendor_url: https://www.github.com

--- a/_vendors/hubspotmarketing.yaml
+++ b/_vendors/hubspotmarketing.yaml
@@ -5,4 +5,4 @@ percent_increase: 6300%
 pricing_source: https://www.hubspot.com/pricing/marketing
 sso_pricing: $2944 per month
 updated_at: 2018-11-23
-url: https://www.hubspot.com
+vendor_url: https://www.hubspot.com

--- a/_vendors/intercom.yaml
+++ b/_vendors/intercom.yaml
@@ -7,4 +7,4 @@ pricing_source:
 - https://www.intercom.com/pricing
 sso_pricing: $202
 updated_at: 2018-10-20
-url: https://www.intercom.com
+vendor_url: https://www.intercom.com

--- a/_vendors/itglue.yaml
+++ b/_vendors/itglue.yaml
@@ -5,4 +5,4 @@ percent_increase: 105%
 pricing_source: https://www.itglue.com/pricing/
 sso_pricing: $39 per u/m
 updated_at: 2019-10-29
-url: https://www.itglue.com
+vendor_url: https://www.itglue.com

--- a/_vendors/jfrog.yaml
+++ b/_vendors/jfrog.yaml
@@ -7,4 +7,4 @@ percent_increase: 613%
 pricing_source: https://jfrog.com/pricing/
 sso_pricing: $699/mo[^jfrog]
 updated_at: 2021-09-06
-url: https://jfrog.com/
+vendor_url: https://jfrog.com/

--- a/_vendors/launchdarkly.yaml
+++ b/_vendors/launchdarkly.yaml
@@ -6,4 +6,4 @@ pricing_note: Quote
 pricing_source: https://launchdarkly.com/pricing/
 sso_pricing: $125 per u/m
 updated_at: 2020-01-24
-url: https://launchdarkly.com
+vendor_url: https://launchdarkly.com

--- a/_vendors/lucidchart.yaml
+++ b/_vendors/lucidchart.yaml
@@ -5,4 +5,4 @@ percent_increase: ???
 pricing_source: https://www.lucidchart.com/users/registerLevel
 sso_pricing: Call Us!
 updated_at: 2018-10-17
-url: https://www.lucidchart.com
+vendor_url: https://www.lucidchart.com

--- a/_vendors/mattermost.yaml
+++ b/_vendors/mattermost.yaml
@@ -5,4 +5,4 @@ percent_increase: 162%
 pricing_source: https://mattermost.com/pricing/
 sso_pricing: $8.50 per u/m
 updated_at: 2019-06-25
-url: https://www.mattermost.com
+vendor_url: https://www.mattermost.com

--- a/_vendors/miro.yaml
+++ b/_vendors/miro.yaml
@@ -5,4 +5,4 @@ percent_increase: 100%
 pricing_source: https://miro.com/pricing/
 sso_pricing: $16 per u/m
 updated_at: 2019-09-13
-url: https://miro.com
+vendor_url: https://miro.com

--- a/_vendors/mondaycom.yaml
+++ b/_vendors/mondaycom.yaml
@@ -6,4 +6,4 @@ pricing_note: Quote
 pricing_source: https://monday.com/pricing/
 sso_pricing: $27 per u/m
 updated_at: 2020-05-26
-url: https://monday.com
+vendor_url: https://monday.com

--- a/_vendors/mural.yaml
+++ b/_vendors/mural.yaml
@@ -5,4 +5,4 @@ percent_increase: 80%
 pricing_source: https://www.mural.co/pricing
 sso_pricing: $18 per u/m
 updated_at: 2021-09-06
-url: https://www.mural.co/
+vendor_url: https://www.mural.co/

--- a/_vendors/nationbuilder.yaml
+++ b/_vendors/nationbuilder.yaml
@@ -8,4 +8,4 @@ percent_increase: 586%++[^nationbuilder]
 pricing_source: https://nationbuilder.com/pricing
 sso_pricing: Call Us! (over $199/month)
 updated_at: 2019-02-09
-url: https://nationbuilder.com
+vendor_url: https://nationbuilder.com

--- a/_vendors/netlify.yaml
+++ b/_vendors/netlify.yaml
@@ -5,4 +5,4 @@ percent_increase: 421%
 pricing_source: https://www.netlify.com/pricing/
 sso_pricing: $99 per u/m
 updated_at: 2021-09-06
-url: https://www.netlify.com/
+vendor_url: https://www.netlify.com/

--- a/_vendors/newrelicinfrastructure.yaml
+++ b/_vendors/newrelicinfrastructure.yaml
@@ -7,4 +7,4 @@ percent_increase: 100%
 pricing_source: https://newrelic.com/products/infrastructure/pricing
 sso_pricing: $1.20 - $14.40 per host-month
 updated_at: 2018-10-18
-url: https://newrelic.com/products/infrastructure
+vendor_url: https://newrelic.com/products/infrastructure

--- a/_vendors/notion.yaml
+++ b/_vendors/notion.yaml
@@ -5,4 +5,4 @@ percent_increase: 150%
 pricing_source: https://www.notion.so/Plans-pricing-6067b27f7a244ccc8320c984baea61d7#bbb051f972bb45c8a8c250ed8ae686ea
 sso_pricing: $20 per u/m
 updated_at: 2020-04-29
-url: https://www.notion.so
+vendor_url: https://www.notion.so

--- a/_vendors/opsgenie.yaml
+++ b/_vendors/opsgenie.yaml
@@ -5,4 +5,4 @@ percent_increase: 111%
 pricing_source: https://www.opsgenie.com/pricing
 sso_pricing: $19 per u/m
 updated_at: 2018-11-08
-url: https://www.opsgenie.com/
+vendor_url: https://www.opsgenie.com/

--- a/_vendors/pagertree.yaml
+++ b/_vendors/pagertree.yaml
@@ -5,4 +5,4 @@ percent_increase: 50%
 pricing_source: https://pagertree.com/pricing/
 sso_pricing: $15 per u/m
 updated_at: 2018-11-08
-url: https://pagertree.com
+vendor_url: https://pagertree.com

--- a/_vendors/pandadoc.yaml
+++ b/_vendors/pandadoc.yaml
@@ -9,4 +9,4 @@ pricing_note: Quote
 pricing_source: https://www.pandadoc.com/pricing/
 sso_pricing: $59 per u/m[^pandadoc]
 updated_at: 2019-10-16
-url: https://www.pandadoc.com
+vendor_url: https://www.pandadoc.com

--- a/_vendors/playvox.yaml
+++ b/_vendors/playvox.yaml
@@ -5,4 +5,4 @@ percent_increase: 100%
 pricing_source: https://www.playvox.com/pricing
 sso_pricing: $30 per u/m
 updated_at: 2020-06-09
-url: https://www.playvox.com
+vendor_url: https://www.playvox.com

--- a/_vendors/postman.yaml
+++ b/_vendors/postman.yaml
@@ -5,4 +5,4 @@ percent_increase: 100%
 pricing_source: https://www.postman.com/pricing
 sso_pricing: $24 per u/m
 updated_at: 2020-02-19
-url: https://www.postman.com/
+vendor_url: https://www.postman.com/

--- a/_vendors/projectmanager.yaml
+++ b/_vendors/projectmanager.yaml
@@ -6,4 +6,4 @@ pricing_source: https://www.projectmanager.com/pricing
 pricing_note: Quote
 sso_pricing: $45 per u/m
 updated_at: 2022-03-30
-url: https://www.projectmanager.com/
+vendor_url: https://www.projectmanager.com/

--- a/_vendors/quip.yaml
+++ b/_vendors/quip.yaml
@@ -5,4 +5,4 @@ percent_increase: 150%
 pricing_source: https://quip.com/about/pricing
 sso_pricing: $25 per u/m
 updated_at: 2019-02-15
-url: https://quip.com/
+vendor_url: https://quip.com/

--- a/_vendors/raygun.yaml
+++ b/_vendors/raygun.yaml
@@ -8,4 +8,4 @@ percent_increase: 721%
 pricing_source: https://raygun.com/platform/crash-reporting
 sso_pricing: $649/mo
 updated_at: 2019-10-10
-url: https://raygun.com
+vendor_url: https://raygun.com

--- a/_vendors/readme.yaml
+++ b/_vendors/readme.yaml
@@ -5,4 +5,4 @@ percent_increase: 1920%
 pricing_source: https://readme.com/pricing
 sso_pricing: $2000 per project/mo
 updated_at: 2020-10-30
-url: https://readme.com
+vendor_url: https://readme.com

--- a/_vendors/ringcentral.yaml
+++ b/_vendors/ringcentral.yaml
@@ -5,4 +5,4 @@ percent_increase: 40%
 pricing_source: https://www.ringcentral.com/office/plansandpricing.html
 sso_pricing: $35 per u/m
 updated_at: 2018-10-17
-url: https://www.ringcentral.com
+vendor_url: https://www.ringcentral.com

--- a/_vendors/rocketchatcloud.yaml
+++ b/_vendors/rocketchatcloud.yaml
@@ -5,4 +5,4 @@ percent_increase: 100%
 pricing_source: https://rocket.chat/pricing#cloud
 sso_pricing: $4 per u/m
 updated_at: 2018-10-22
-url: https://rocket.chat/
+vendor_url: https://rocket.chat/

--- a/_vendors/sentry.yaml
+++ b/_vendors/sentry.yaml
@@ -5,4 +5,4 @@ percent_increase: 208%
 pricing_source: https://sentry.io/pricing/
 sso_pricing: $80 for 100K events
 updated_at: 2018-10-20
-url: https://sentry.io
+vendor_url: https://sentry.io

--- a/_vendors/slack.yaml
+++ b/_vendors/slack.yaml
@@ -5,4 +5,4 @@ percent_increase: 87%
 pricing_source: https://slack.com/pricing
 sso_pricing: $12.50 per u/m
 updated_at: 2018-10-17
-url: https://slack.com
+vendor_url: https://slack.com

--- a/_vendors/smartsheet.yaml
+++ b/_vendors/smartsheet.yaml
@@ -5,4 +5,4 @@ percent_increase: ???
 pricing_source: https://www.smartsheet.com/pricing
 sso_pricing: Call us!
 updated_at: 2018-10-22
-url: https://smartsheet.com
+vendor_url: https://smartsheet.com

--- a/_vendors/snyk.yaml
+++ b/_vendors/snyk.yaml
@@ -5,4 +5,4 @@ percent_increase: 67%
 pricing_source: https://snyk.io/plans
 sso_pricing: $39.98 per u/m
 updated_at: 2018-10-22
-url: https://snyk.io
+vendor_url: https://snyk.io

--- a/_vendors/squadcast.yaml
+++ b/_vendors/squadcast.yaml
@@ -7,4 +7,4 @@ percent_increase: 111%
 pricing_source: https://www.squadcast.com/pricing
 sso_pricing: $19 per u/m [^squadcast]
 updated_at: 2019-12-21
-url: https://www.squadcast.com
+vendor_url: https://www.squadcast.com

--- a/_vendors/surveymonkey.yaml
+++ b/_vendors/surveymonkey.yaml
@@ -5,4 +5,4 @@ percent_increase: 200%++
 pricing_source: https://www.surveymonkey.com/pricing/details/
 sso_pricing: Call Us! (over $75 per u/m)
 updated_at: 2021-09-06
-url: https://www.surveymonkey.com
+vendor_url: https://www.surveymonkey.com

--- a/_vendors/testrailcloud.yaml
+++ b/_vendors/testrailcloud.yaml
@@ -5,4 +5,4 @@ percent_increase: 92%
 pricing_source: https://www.gurock.com/testrail/pricing/cloud-enterprise
 sso_pricing: $69 per u/m
 updated_at: 2021-09-06
-url: https://www.gurock.com/testrail/
+vendor_url: https://www.gurock.com/testrail/

--- a/_vendors/trello.yaml
+++ b/_vendors/trello.yaml
@@ -5,4 +5,4 @@ percent_increase: 110%
 pricing_source: https://trello.com/pricing
 sso_pricing: $21 per u/m
 updated_at: 2018-10-17
-url: https://trello.com
+vendor_url: https://trello.com

--- a/_vendors/twilio.yaml
+++ b/_vendors/twilio.yaml
@@ -7,4 +7,4 @@ percent_increase: 30%
 pricing_source: https://www.twilio.com/enterprise
 sso_pricing: See Notes[^twilio]
 updated_at: 2018-10-22
-url: https://twilio.com
+vendor_url: https://twilio.com

--- a/_vendors/victorops.yaml
+++ b/_vendors/victorops.yaml
@@ -6,4 +6,4 @@ percent_increase: 69%
 pricing_source: https://victorops.com/pricing
 sso_pricing: $49 per u/m[^victorops]
 updated_at: 2018-10-17
-url: https://victorops.com
+vendor_url: https://victorops.com

--- a/_vendors/zapier.yaml
+++ b/_vendors/zapier.yaml
@@ -5,4 +5,4 @@ percent_increase: 100%
 pricing_source: https://zapier.com/app/billing/plans/
 sso_pricing: $600 per u/m
 updated_at: 2019-10-19
-url: https://zapier.com/
+vendor_url: https://zapier.com/

--- a/_vendors/zeplin.yaml
+++ b/_vendors/zeplin.yaml
@@ -7,4 +7,4 @@ percent_increase: 100%
 pricing_source: Quote
 sso_pricing: $21.50 per u/m[^zeplin]
 updated_at: 2021-01-06
-url: https://zeplin.io/
+vendor_url: https://zeplin.io/

--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 {% assign vendors = site.vendors | sort: "name" %}
 {% for vendor in vendors %}
 <tr>
-<td markdown="span"><a href="{{ vendor.url }}">{{ vendor.name }}</a></td>
+<td markdown="span"><a href="{{ vendor.vendor_url }}">{{ vendor.name }}</a></td>
 <td markdown="span">{{ vendor.base_pricing }}</td>
 <td markdown="span">{{ vendor.sso_pricing }}</td>
 <td markdown="span">{{ vendor.percent_increase }}</td>


### PR DESCRIPTION
In #254, we migrated to using a Jekyll collection to keep each vendor contained to its own yaml file. As part of this,
Jekyll injects its own `url` parameter into the resulting document. This has caused all homepage vendor links to be
broken.

To address this, vendors will now use `vendor_url` to note the vendor homepage.