### PR TITLE
Add Mailtrap

### DIFF
--- a/_vendors/mailtrap.yaml
+++ b/_vendors/mailtrap.yaml
@@ -1,7 +1,7 @@
 ---
-base_pricing: $9.99 per month
+base_pricing: $24.99 per month
 name: Mailtrap
-percent_increase: 2902%
+percent_increase: 1100%
 pricing_source: https://mailtrap.io/pricing/
 sso_pricing: $299.99 per month
 updated_at: 2022-06-14

--- a/_vendors/mailtrap.yaml
+++ b/_vendors/mailtrap.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $9.99 per month
+name: Mailtrap
+percent_increase: 2902%
+pricing_source: https://mailtrap.io/pricing/
+sso_pricing: $299.99 per month
+updated_at: 2022-06-14
+vendor_url: https://mailtrap.io


### PR DESCRIPTION
Adds Mailtrap, pricing from: https://mailtrap.io/pricing/

Chose the cheapest paid plan for the base price, please shout if that's the wrong way to do it