### PR TITLE
add balsamiq

### DIFF
--- a/_vendors/balsamiq.yaml
+++ b/_vendors/balsamiq.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $9 (2 projects) /m
+name: Balsamiq Wireframes
+percent_increase: 2112%
+pricing_source: https://balsamiq.com/buy/#cloud
+sso_pricing: $199 (200 projects) /m
+updated_at: 2022-08-19
+vendor_url: https://balsamiq.com/


### PR DESCRIPTION
---
name: Balsamiq Wireframes
about: PR is filled with _vendor yaml. I'm happy to adjust this to the $49 tier being the 'base' if we see fit.

---

**What is the vendor's name?**
Balsamiq Wireframes

**What is the vendor's pricing site?**
https://balsamiq.com/buy/#cloud

**What is the base pricing? Use the lowest tier that looks sane for a small business customer, not free or personal tiers.**
$9 / 2 projects / month
$49 / 20 projects / month

**What is the minimum pricing for SSO support?**
$199 / 200 projects /month

**Does this pricing info come from a quote or other non-public source?**
N/A

**Are there any caveats we should list in the footnotes?**
There are slight discounts for annual pricing. In our personal use of Balsamiq, we do not need more than 1 'project' of wireframes, though I could see a larger operation than mine using the $49 tier.