### PR TITLE
Added Pamoja Education

### DIFF
--- a/_vendors/pamoja.yaml
+++ b/_vendors/pamoja.yaml
@@ -1,0 +1,9 @@
+---
+base_pricing: $48 per student
+name: Pamoja Education / ManageBac / Faria Group
+percent_increase: 27%
+pricing_note: Quote
+pricing_source: https://www.managebac.com/contactsales
+sso_pricing: $12.80 per student
+updated_at: 2022-08-22
+vendor_url: https://www.managebac.com/passport


### PR DESCRIPTION
Price is to add SSO to ManageBac Passport using Google Auth
Contract is with Pamoja Education but they are also known as ManageBac or Faria Group after multiple M&A steps