### PR TITLE
feat(vendor): add datocms

### DIFF
--- a/_vendors/datocms.yaml
+++ b/_vendors/datocms.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $100 per month
+name: DatoCMS
+percent_increase: 666,67%
+pricing_source: https://www.datocms.com/pricing
+sso_pricing: $666,67 per month
+updated_at: 2022-09-27
+vendor_url: https://datocms.com


### PR DESCRIPTION
DatoCMS offers an unlisted 'Interim' tier for 8K per year compared to 1.2K/year.
This includes SSO and audit logging.