### PR TITLE
Add zoom

### DIFF
--- a/_vendors/zoom.yaml
+++ b/_vendors/zoom.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $14.99 per u/m
+name: Zoom
+percent_increase: 33.3%
+pricing_source: https://zoom.us/pricing
+sso_pricing: $19.99 per u/m
+updated_at: 2022-10-31
+vendor_url: https://zoom.us/


### PR DESCRIPTION
Zoom requires a vanity URL to enable SSO which is only available in their Business plan or above.