### PR TITLE
Create mailjet.yaml

### DIFF
--- a/_vendors/mailjet.yaml
+++ b/_vendors/mailjet.yaml
@@ -1,0 +1,10 @@
+---
+base_pricing: $25 per month
+name: Mailjet
+percent_increase: 280%
+pricing_source:
+- https://documentation.mailjet.com/hc/en-us/articles/5216831817499-How-to-enable-SAML-SSO-with-Mailjet#h_01G01MC9HVB5DYRJKSERS9FHTK
+- https://www.mailjet.com/pricing/
+sso_pricing: $95 per month
+updated_at: 2023-04-26
+vendor_url: https://www.mailjet.com


### PR DESCRIPTION
Base price is the smallest non-free plan that has multi-user access (Premium 15k/month). They have a cheaper plan that doesn't have multi-user access, but I chose to compare the SSO price against the price for multi-user access without SSO.

SSO price is the price of the Premium 100k/month plan, as mentioned in their documentation:

> Note: SAML SSO is available from 100,000 Premium Plan and Custom Accounts.

