### PR TITLE
Remove Aqua as they offer SSO for all products at every tier.

### DIFF
--- a/_vendors/aqua.yaml
+++ b/_vendors/aqua.yaml
@@ -1,8 +1,0 @@
----
-base_pricing: $849 per month
-name: Aqua
-percent_increase: 147%
-pricing_source: https://aquasec.com/pricing/
-sso_pricing: $2099 per month
-updated_at: 2021-09-06
-vendor_url: https://aquasec.com


### PR DESCRIPTION
The history of Aqua appearing on the list is here: https://github.com/robchahin/sso-wall-of-shame/pull/148

In a nutshell, Aqua acquired CloudSploit, which at the time, may have met the criteria for shaming.  However, the CloudSploit AuthN/AuthZ functionality has long since been depricated. 

Aqua offers two products:

- **On-premise software**:  This has included SSO included in every license since the inception of the company.
- **SaaS offering**: This has also always offered SSO at every license level since its inception, however, previous pricing description made it unclear, whether or not SSO was included (it always was).

Here's the pricing page today.  You'll see there's nothing to suggest that SSO is a licensed feature: https://www.aquasec.com/pricing/

If additional proof or details are needed, please let me know.  I'm an engineer at Aqua and I've worked extensively on SSO projects.