### PR TITLE
Add vendor (Dmarcian)

### DIFF
--- a/_vendors/dmarcian.yaml
+++ b/_vendors/dmarcian.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $24 / month
+name: Dmarcian
+percent_increase: 2400%
+pricing_source: https://dmarcian.com/pricing/
+sso_pricing: $600 / month
+updated_at: 2023-09-20
+vendor_url: https://dmarcian.com


### PR DESCRIPTION
SSO only available at the Enterprise tier