### PR TITLE
postman raised their SSO prices

### DIFF
--- a/_vendors/postman.yaml
+++ b/_vendors/postman.yaml
@@ -1,7 +1,7 @@
 ---
 base_pricing: $12 per u/m
 name: Postman
-percent_increase: 408%
+percent_increase: 308%
 pricing_source: https://www.postman.com/pricing
 sso_pricing: $49 per u/m
 updated_at: 2023-12-10

--- a/_vendors/postman.yaml
+++ b/_vendors/postman.yaml
@@ -1,8 +1,8 @@
 ---
 base_pricing: $12 per u/m
 name: Postman
-percent_increase: 100%
+percent_increase: 408%
 pricing_source: https://www.postman.com/pricing
-sso_pricing: $24 per u/m
-updated_at: 2020-02-19
+sso_pricing: $49 per u/m
+updated_at: 2023-12-10
 vendor_url: https://www.postman.com/


### PR DESCRIPTION
from $24 to $49 per user/month (billed annually, of course).