### PR TITLE
add cypress.io

### DIFF
--- a/_vendors/cypress.yaml
+++ b/_vendors/cypress.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $75 per month
+name: Cypress.io
+percent_increase: 400%
+pricing_source: https://www.cypress.io/pricing#monthly
+sso_pricing: $300 per month
+updated_at: 2023-10-31
+vendor_url: https://www.cypress.io/

--- a/_vendors/cypress.yaml
+++ b/_vendors/cypress.yaml
@@ -1,7 +1,7 @@
 ---
 base_pricing: $75 per month
 name: Cypress.io
-percent_increase: 400%
+percent_increase: 300%
 pricing_source: https://www.cypress.io/pricing#monthly
 sso_pricing: $300 per month
 updated_at: 2023-10-31


### PR DESCRIPTION
This PR will also close #239 (is in new format)
---
name: Cypress.io
about: PR is filled with _vendor yaml. Cypress.io has just increased their "Team" tier to match the same user count. Difference in tiers:

- Team
  - $75 / month
  - 50 Users
  - 10,000 Tests

- Business
  - $300 / month
  - 50 Users
  - 10,000 Tests
  - Adds a handful of other features such as Spec Prioritization, Auto Cancellation, GitHub Enterprise & ​On-Prem GitLab

As you can see above, there is a 400% price increase for single sign on and features that should not cost extra in my opinion. 🤷‍♂️