### PR TITLE
Add Quoter per Issue 427

### DIFF
--- a/_vendors/quoter.yaml
+++ b/_vendors/quoter.yaml
@@ -1,0 +1,10 @@
+---
+base_pricing: $199/mo[^quoter]
+footnotes: "[^quoter]: Quoter offers a lower tier at $99/mo but it's intended for individuals. The lowest tier supporting SSO is $299/mo but SSO is available as an add-on for $59/mo so the lower cost is used here."
+name: Quoter
+percent_increase: 30%
+pricing_source: https://www.quoter.com/pricing/
+sso_pricing: $258/mo[^quoter]
+updated_at: 2023-11-10
+vendor_url: https://www.quoter.com/
+


### PR DESCRIPTION
Adding Quoter - using price for lowest business tier + SSO add-on as the SSO cost as it's less than the lowest tier that includes SSO.