### PR TITLE
Create bytebase.yaml

### DIFF
--- a/_vendors/bytebase.yaml
+++ b/_vendors/bytebase.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $995 per year
+name: Bytebase
+percent_increase: ???
+pricing_source: https://www.bytebase.com/pricing/
+sso_pricing: Call Us!
+updated_at: 2024-02-12
+vendor_url: https://www.bytebase.com/


### PR DESCRIPTION
SSO is part of their Enterprise plan as per https://www.bytebase.com/pricing/

Note that even 2FA (which is the bare minimum for such product that provide access to databases) also requires their Enterprise tier! :exploding_head: 