### PR TITLE
Add Temporal Cloud

### DIFF
--- a/_vendors/temporalcloud.yaml
+++ b/_vendors/temporalcloud.yaml
@@ -1,0 +1,10 @@
+---
+base_pricing: $25 per 1,000,000 actions, $0.042 per GB per hour
+footnotes: '[^temporal-price]: Pay-as-you-go based on actions and storage with an additional $200 support fee regardless of SSO.'
+name: Temporal Cloud
+percent_increase: 100%
+pricing_note: Quote
+pricing_source: https://temporal.io/pricing
+sso_pricing: $200 per month
+updated_at: 2024-04-09
+vendor_url: https://temporal.io

--- a/_vendors/temporalcloud.yaml
+++ b/_vendors/temporalcloud.yaml
@@ -1,10 +1,11 @@
 ---
-base_pricing: $25 per 1,000,000 actions, $0.042 per GB per hour
-footnotes: '[^temporal-price]: Pay-as-you-go based on actions and storage with an additional $200 support fee regardless of SSO.'
+base_pricing: $200 per month[^temporal]
+footnotes: '[^temporal]: Pay-as-you-go based on actions and storage with an additional $200 support fee. SSO requires an additional monthly fee of $200 to $500 depending on users.'
 name: Temporal Cloud
-percent_increase: 100%
-pricing_note: Quote
-pricing_source: https://temporal.io/pricing
-sso_pricing: $200 per month
-updated_at: 2024-04-09
+percent_increase: 100%+
+pricing_source:
+- https://temporal.io/pricing
+- https://docs.temporal.io/cloud/pricing#sso-and-saml
+sso_pricing: $400+ per month[^temporal]
+updated_at: 2024-12-27
 vendor_url: https://temporal.io


### PR DESCRIPTION
Adding Temporal Cloud per their https://temporal.io/pricing page.

Bare-minimum pricing for use is $200 for the support fee. Adding SAML is an additional $200 per month.

Pricing based on the assumption of a business using a real IDP like Okta.