### PR TITLE
Add Jam to vendors

### DIFF
--- a/_vendors/jam.yaml
+++ b/_vendors/jam.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $8 per u/m
+name: Jam
+percent_increase: ???
+pricing_source: https://jam.dev/pricing
+sso_pricing: Call Us!
+updated_at: 2024-05-11
+vendor_url: https://jam.dev


### PR DESCRIPTION
Jam is a browser extension that allows you to create the perfect bug report in just one click.  They recently had a story on Hacker News and [I encouraged them to provide SSO for all their plans](https://news.ycombinator.com/item?id=40327763).  

Here was their reply:


>Great feedback, thank you!
>
>Our philosophy on pricing is to try and only make what real companies who can pay need, and offer what individuals and hobbyists and small startups need for for free, so that’s why SSO ended up a paid feature. But it’s great feedback for us - thank you! 
