### PR TITLE
Revive canva.yaml

### DIFF
--- a/_vendors/canva.yaml
+++ b/_vendors/canva.yaml
@@ -1,0 +1,9 @@
+---
+base_pricing: $10 per u/m
+name: Canva
+percent_increase: 100%
+pricing_source: https://www.canva.com/pricing/
+sso_pricing: $20 per u/m
+pricing_note: Quote
+updated_at: 2024-05-28
+vendor_url: https://canva.com/


### PR DESCRIPTION
It was deleted at https://github.com/robchahin/sso-wall-of-shame/pull/342 but recently they revised their paid plans and SSO/SCIM went behind their Enterprise plan again.