### PR TITLE
Amend canva.yaml

### DIFF
--- a/_vendors/canva.yaml
+++ b/_vendors/canva.yaml
@@ -1,9 +1,9 @@
 ---
-base_pricing: $10 per u/m
+base_pricing: $10 per u/m (minimum purchase amount is $30 per m)
 name: Canva
-percent_increase: 100%
+percent_increase: 300%
 pricing_source: https://www.canva.com/pricing/
-sso_pricing: $20 per u/m
+sso_pricing: $40 per u/m (minimum purchase amount is $12000 per year, paid upfront)
 pricing_note: Quote
-updated_at: 2024-05-28
+updated_at: 2024-06-17
 vendor_url: https://canva.com/

--- a/_vendors/canva.yaml
+++ b/_vendors/canva.yaml
@@ -1,9 +1,10 @@
 ---
-base_pricing: $10 per u/m (minimum purchase amount is $30 per m)
+base_pricing: $10 per u/m[^canva]
 name: Canva
-percent_increase: 300%
+footnotes: '[^canva]: Minimum spend on base tier is $30/month; Minimum spend on SSO is $12,000/year paid upfront.'
+percent_increase: 300%[^canva]
 pricing_source: https://www.canva.com/pricing/
-sso_pricing: $40 per u/m (minimum purchase amount is $12000 per year, paid upfront)
+sso_pricing: $40 per u/m[^canva]
 pricing_note: Quote
 updated_at: 2024-06-17
 vendor_url: https://canva.com/


### PR DESCRIPTION
In order to enable SSO/SCIM (only available on the Enterprise plan) 25 licenses must be purchased with one year in advance payment (yearly billing cycle).

The sales representative did not agree to reduce the number of licenses to purchase the Enterprise plan, citing current company policy.