### PR TITLE
Updated Balsamiq pricing

### DIFF
--- a/_vendors/balsamiq.yaml
+++ b/_vendors/balsamiq.yaml
@@ -1,8 +1,8 @@
 ---
 base_pricing: $9 per month
 name: Balsamiq Wireframes
-percent_increase: 306%
-pricing_source: https://balsamiq.com/buy/#cloud
-sso_pricing: $199 per month
-updated_at: 2023-10-15
+percent_increase: 56%
+pricing_source: https://balsamiq.com/buy
+sso_pricing: $14 per month
+updated_at: 2024-07-28
 vendor_url: https://balsamiq.com/


### PR DESCRIPTION
Balsamiq's SSO tax is now only 56% (down from 306%) as of today