### PR TITLE
Delete _vendors/zapier.yaml

### DIFF
--- a/_vendors/zapier.yaml
+++ b/_vendors/zapier.yaml
@@ -1,8 +1,0 @@
----
-base_pricing: $299 per u/m
-name: Zapier
-percent_increase: 100%
-pricing_source: https://zapier.com/app/billing/plans/
-sso_pricing: $600 per u/m
-updated_at: 2019-10-19
-vendor_url: https://zapier.com/


### PR DESCRIPTION
Zapier moved SAML to the teams plan which is capped at 25 users, but is the cheapest multi-user plan. As such I don't believe it qualifies for sso.tax anymore.