### PR TITLE
Update ReadMe pricing data

### DIFF
--- a/_vendors/readme.yaml
+++ b/_vendors/readme.yaml
@@ -1,8 +1,8 @@
 ---
 base_pricing: $99 per project/mo
 name: ReadMe
-percent_increase: 1920%
+percent_increase: 2930%
 pricing_source: https://readme.com/pricing
-sso_pricing: $2000 per project/mo
-updated_at: 2020-10-30
+sso_pricing: $3000 per project/mo
+updated_at: 2024-02-25
 vendor_url: https://readme.com


### PR DESCRIPTION
Their Enterprise plan has gone up to $3000 and is still the only plan with SSO.