### PR TITLE
Update mailtrap.yaml

### DIFF
--- a/_vendors/mailtrap.yaml
+++ b/_vendors/mailtrap.yaml
@@ -1,8 +1,8 @@
 ---
 base_pricing: $30 per month
 name: Mailtrap
-percent_increase: 280%
+percent_increase: 183%
 pricing_source: https://mailtrap.io/pricing/
 sso_pricing: $85 per month
-updated_at: 2025-05-05
+updated_at: 2025-09-26
 vendor_url: https://mailtrap.io

--- a/_vendors/mailtrap.yaml
+++ b/_vendors/mailtrap.yaml
@@ -1,8 +1,8 @@
 ---
-base_pricing: $24.99 per month
+base_pricing: $30 per month
 name: Mailtrap
-percent_increase: 1100%
+percent_increase: 280%
 pricing_source: https://mailtrap.io/pricing/
-sso_pricing: $299.99 per month
-updated_at: 2022-06-14
+sso_pricing: $85 per month
+updated_at: 2025-05-05
 vendor_url: https://mailtrap.io


### PR DESCRIPTION
The prices for mailtrap have changed and the best comparison is now "Basic 100K" with 100,000 mails/mo vs. "Business 100K" which includes SSO. This is 30 vs. 85 bucks.