### PR TITLE
Create statusgator.yaml

### DIFF
--- a/_vendors/statusgator.yaml
+++ b/_vendors/statusgator.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: (Free) or Starter $72/month
+name: Status Gator
+percent_increase: 1010%
+pricing_source: https://statusgator.com/plans
+sso_pricing: $799/month
+updated_at: 2025-06-23
+vendor_url: https://statusgator.com

--- a/_vendors/statusgator.yaml
+++ b/_vendors/statusgator.yaml
@@ -1,8 +1,8 @@
 ---
-base_pricing: (Free) or Starter $72/month
+base_pricing: $149 per month
 name: Status Gator
-percent_increase: 1010%
+percent_increase: 436%
 pricing_source: https://statusgator.com/plans
-sso_pricing: $799/month
-updated_at: 2025-06-23
+sso_pricing: $799 per month
+updated_at: 2025-08-23
 vendor_url: https://statusgator.com


### PR DESCRIPTION
Statusgator want to charge you $9,588/year to simply use SSO.
We recently evaluated using Statusgator. We only needed a "Team" plan at $1,644/year. We were about to purchase only to discover that Status Pages don't support SSO unless you pay for an "Enterprise" licence. 