### PR TITLE
Add Genetec SaaS

### DIFF
--- a/_vendors/genetec.yaml
+++ b/_vendors/genetec.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $99 per connection per year
+footnotes: '[^genetec-price]: Each unique camera/device counts as a connection.'
 name: Genetec Video SaaS
 percent_increase: 51%+
 pricing_source: https://www.genetec.com/products/unified-security/security-center-saas/saas-pricing
-sso_pricing: $149 per connection per year
-pricing_note: A 'connection' is a camera. A building with 10 cameras pays $500 extra per year for SSO.
+sso_pricing: $149 per connection per year[^genetec-price]
 updated_at: 2025-08-19
 vendor_url: https://genetec.com

--- a/_vendors/genetec.yaml
+++ b/_vendors/genetec.yaml
@@ -1,0 +1,9 @@
+---
+base_pricing: $99 per connection per year
+name: Genetec Video SaaS
+percent_increase: 51%+
+pricing_source: https://www.genetec.com/products/unified-security/security-center-saas/saas-pricing
+sso_pricing: $149 per connection per year
+pricing_note: A 'connection' is a camera. A building with 10 cameras pays $500 extra per year for SSO.
+updated_at: 2025-08-19
+vendor_url: https://genetec.com


### PR DESCRIPTION
Their pricing is _per connection_ which can add up quickly on a building with lots of cameras. The SSO tax is per connection, not a flat extra. Brutal.