### PR TITLE
add SocialPilot

### DIFF
--- a/_vendors/socialpilot.yaml
+++ b/_vendors/socialpilot.yaml
@@ -3,6 +3,6 @@ base_pricing: $30 per month
 name: Social Pilot
 percent_increase: ???
 pricing_source: https://www.socialpilot.co/plans
-sso_pricing: Call Us! ($30+)
+sso_pricing: Call Us!
 updated_at: 2025-09-02
 vendor_url: https://www.socialpilot.co/

--- a/_vendors/socialpilot.yaml
+++ b/_vendors/socialpilot.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $30 per month
+name: Social Pilot
+percent_increase: ???
+pricing_source: https://www.socialpilot.co/plans
+sso_pricing: Call Us! ($30+)
+updated_at: 2025-09-02
+vendor_url: https://www.socialpilot.co/


### PR DESCRIPTION
Social Pilot is a popular social media management application. They only allow SSO on "enterprise" plans which I've contacted them to ask about pricing and gotten nothing back.