### PR TITLE
Add Minio

### DIFF
--- a/_vendors/minio.yaml
+++ b/_vendors/minio.yaml
@@ -1,0 +1,9 @@
+---
+base_pricing: Quote[^Minio]
+name: Minio
+percent_increase: 100%
+pricing_source: https://www.min.io/pricing
+sso_pricing: Quote
+footnotes: '[^Minio]: Usage of OIDC and LDP used to be free, however they have since then removed this from the OSS version of Minio, and locked it behind their AiStor product. Even when it was part of the free tier, Minio prevented core functionality as per issue 20333, locking it behind their enterprise offerings: https://github.com/minio/minio/pull/20333'
+updated_at: 2025-09-07
+vendor_url: https://www.min.io/


### PR DESCRIPTION
Minio has recently removed all SSO offerings from their free tier of product, locking it behind their new enterprise offering, AiStor. They have also been hostile toward improvements to their SSO offering in the past in previous issues.

See minio/minio#20333 and https://github.com/minio/minio/releases/tag/RELEASE.2025-05-24T17-08-30Z for more details. 