### PR TITLE
Add vendor Channel.io

### DIFF
--- a/_vendors/channelio.yaml
+++ b/_vendors/channelio.yaml
@@ -1,5 +1,5 @@
 ---
-base_pricing: Call Us!
+base_pricing: $36 per month
 name: Channel.io
 percent_increase: ???
 pricing_source: https://docs.channel.io/help/en/articles/cd70a19d


### PR DESCRIPTION
Reference: https://channel.io/en/pricing, https://docs.channel.io/help/en/articles/cd70a19d

They require an enterprise plan to use SSO and the price has not been announced. So both the base price and the SSO price are marked as 'call us'.