### PR TITLE
Add Overleaf as a new vendor

### DIFF
--- a/_vendors/overleaf.yaml
+++ b/_vendors/overleaf.yaml
@@ -1,0 +1,8 @@
+---
+base_pricing: $179 per u/y
+name: Overleaf
+percent_increase: 100%
+pricing_source: https://www.overleaf.com/user/subscription/plans?plan=group
+sso_pricing: $359 per u/y
+updated_at: 2026-01-18
+vendor_url: https://www.overleaf.com/


### PR DESCRIPTION
Reference: https://www.overleaf.com/user/subscription/plans?plan=group

SSO integration requires the "Group Professional" plan at roughly double the cost of the base group subscription.

A self-hosted _community version_ is available (https://github.com/overleaf/overleaf), however without SSO support either (self-hosted SSO support requires "Overleaf Server Pro", to which the pricing is "contact us").