### PR TITLE
Add PostHog to SSO wall of shame

### DIFF
--- a/_vendors/posthog.yaml
+++ b/_vendors/posthog.yaml
@@ -3,7 +3,7 @@ base_pricing: Usage-based (starts at $0, generous free tier)
 footnotes: '[^posthog]: Basic SSO (GitHub, GitLab, Google) is available on all plans including Free, but SSO enforcement requires the Boost add-on at $250/mo. SAML and SCIM SSO require the Scale add-on at $750/mo.'
 name: PostHog
 percent_increase: N/A[^posthog]
-pricing_source: https://posthog.com/pricing
+pricing_source: https://posthog.com/platform-packages
 sso_pricing: $250 per month (Boost add-on for SSO enforcement)[^posthog]
 updated_at: 2026-01-29
 vendor_url: https://posthog.com


### PR DESCRIPTION
PostHog requires a $250/mo Boost add-on for SSO enforcement, and $750/mo Scale add-on for SAML/SCIM SSO support, while basic SSO (GitHub, GitLab, Google) is available on all plans.

This qualifies PostHog for the SSO wall of shame as SSO enforcement is treated as a premium feature requiring a paid add-on.