### PR TITLE
Add Wedo as a new vendor

### DIFF
--- a/_vendors/wedo.yaml
+++ b/_vendors/wedo.yaml
@@ -1,0 +1,10 @@
+---
+base_pricing: $19.90 per u/m
+footnotes: 
+name: Wedo
+percent_increase: 25.13%
+pricing_note: 
+pricing_source: https://wedo.com/de/pricing
+sso_pricing: $24.90 per u/m
+updated_at: 2026-02-03
+vendor_url: https://wedo.com


### PR DESCRIPTION
Added Wedo as Vendor
Wedo is a platform to manage meetings.

Even 2FA is locked behind the Business upgrade.