### PR TITLE
Add railway.yaml with vendor pricing details

### DIFF
--- a/_vendors/railway.yaml
+++ b/_vendors/railway.yaml
@@ -2,7 +2,7 @@
 name: Railway
 base_pricing: $20
 sso_pricing: $2000
-percent_increase: 9.900%
+percent_increase: 9900%
 pricing_note: SSO price only becomes visible when you have already signed up to the Pro plan
 pricing_source: https://railway.com/pricing
 vendor_url: https://railway.com


### PR DESCRIPTION
SSO price is only visible to signed in users, not sure how to show that, maybe a screenshot?

<img width="860" height="2058" alt="railway-cropped" src="https://github.com/user-attachments/assets/18ec2711-4fcd-4831-95ff-4a615721cee3" />