### PR TITLE
fix: Correct percentage math for miscalculated vendors

### DIFF
--- a/_vendors/clockify.yaml
+++ b/_vendors/clockify.yaml
@@ -1,7 +1,7 @@
 ---
 base_pricing: $3.99 per u/m
 name: Clockify
-percent_increase: 300%
+percent_increase: 201%
 pricing_source: https://clockify.me/extra-features
 sso_pricing: $11.99 per u/m
 updated_at: 2021-03-17

--- a/_vendors/metabase.yaml
+++ b/_vendors/metabase.yaml
@@ -1,7 +1,7 @@
 ---
 base_pricing: $85 per month[^metabase]
 name: Metabase
-percent_increase: 588%
+percent_increase: 488%
 pricing_source: https://www.metabase.com/pricing/
 sso_pricing: $500 per month
 footnotes: '[^metabase]: Additional 100% increase in monthly user cost ($5->$10) above license increase.'

--- a/_vendors/recruitee.yaml
+++ b/_vendors/recruitee.yaml
@@ -1,7 +1,7 @@
 ---
 base_pricing: $199 per month
 name: Recruitee
-percent_increase: 35%
+percent_increase: 38%
 pricing_source: https://recruitee.com/pricing
 sso_pricing: $274 per month
 updated_at: 2024-08-07

--- a/_vendors/sanity.yaml
+++ b/_vendors/sanity.yaml
@@ -2,7 +2,7 @@
 base_pricing: $15 per u/m
 footnotes: '[^sanity]: SSO price based on 25 users - SSO is available as an account add on or at the price-unlisted enterprise tier.'
 name: Sanity
-percent_increase: 350%
+percent_increase: 373%
 pricing_source: https://www.sanity.io/pricing
 sso_pricing: $70.96 per u/m[^sanity]
 updated_at: 2024-01-23


### PR DESCRIPTION
Had some vendors with bad math, those changes got stashed in a weird branch while working on the validation GH Action, merging them now as housekeeping