### PR TITLE
fix: add vendor/ to Jekyll exclude list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,11 @@ collections:
   - vendors
 
 exclude:
+  - vendor/
   - venv/
   - bin/
   - scripts/
   - tests/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/


### PR DESCRIPTION
Jekyll was processing files inside `vendor/bundle/` (the bundler gem cache) and choking on a template file with an invalid date. 

Adding a custom `exclude:` list in `_config.yml` can cause Jekyll's default excludes (`vendor/`, `Gemfile`, `node_modules/`, etc.) to be lost. This explicitly adds them back.