### PR TITLE
fix: use case-insensitive keyword matching for Call Us vendor routing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # sso.tax Contributing Guidelines
 ## Call Us
-Vendors with the word "Call" in the sso_pricing field are automatically sorted into "The Other List" below "The List."
+Vendors whose `sso_pricing` field contains any of the words "call", "contact", "custom", or "quote" (case-insensitive) are automatically sorted into "The Other List" below "The List." Examples: `Call Us!`, `Contact Sales`, `Custom pricing`.
 
 ## Percentages
 A common error with PRs is a miscalculated percentage. The site uses a "percentage increase from base price model" – that is, a $5 -> $10 markup is a 100% increase, not 200%. I'm hoping that a unit test will catch these, but writing a guideline is quicker.

--- a/index.md
+++ b/index.md
@@ -29,7 +29,8 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 {% assign vendors = "" | split: ',' %}
 {% assign call_us = "" | split: ',' %}
 {% for vendor in all %}
-	{% if vendor.sso_pricing contains "Call" %}
+	{% assign sso_lower = vendor.sso_pricing | downcase %}
+	{% if sso_lower contains "call" or sso_lower contains "contact" or sso_lower contains "custom" or sso_lower contains "quote" %}
 		{% assign call_us = call_us | push: vendor %}
 	{% else %}
 		{% assign vendors = vendors | push: vendor %}


### PR DESCRIPTION
Fixes vendor routing so that pricing values like "Call us", "CALL US", etc. are all correctly detected as the Call Us category, regardless of casing.

## Changes
- `index.md` — case-insensitive matching
- `CONTRIBUTING.md` — documentation update