### PR TITLE
fix: remove duplicate name key from twilio.yaml

### DIFF
--- a/_vendors/twilio.yaml
+++ b/_vendors/twilio.yaml
@@ -2,7 +2,6 @@
 name: Twilio
 base_pricing: ???
 footnotes: '[^twilio]: SSO is an a la carte addon available to any account priced at $1,500 per month. Previously, it was sold as part of all three Twilio Editions, starting at $3,500 per month. This is on top of all normal spend.'
-name: Twilio
 percent_increase: ???%
 pricing_note: Quote
 pricing_source: https://www.twilio.com/editions


### PR DESCRIPTION
Removes a duplicate `name:` key from `_vendors/twilio.yaml` which would fail the new duplicate-key validator.

## Changes
- `_vendors/twilio.yaml` — remove duplicate `name: Twilio` key