### PR TITLE
fix: add aria-label and title to pricing source link anchors

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,7 +54,7 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 {% if forloop.first == false %}
 &amp;
 {% endif %}
-<a href="{{ source }}">&#128279;</a>
+<a href="{{ source }}" aria-label="Pricing source for {{ vendor.name }}" title="Pricing source for {{ vendor.name }}">&#128279;</a>
 {% endfor %}
 {{ vendor.pricing_note }}</td>
 <td>{{ vendor.updated_at }}</td>
@@ -82,7 +82,7 @@ Some vendors simply do not list their pricing for SSO because the pricing is neg
 {% if forloop.first == false %}
 &amp;
 {% endif %}
-<a href="{{ source }}">&#128279;</a>
+<a href="{{ source }}" aria-label="Pricing source for {{ vendor.name }}" title="Pricing source for {{ vendor.name }}">&#128279;</a>
 {% endfor %}
 {{ vendor.pricing_note }}</td>
 <td>{{ vendor.updated_at }}</td>


### PR DESCRIPTION
Improves accessibility of the 🔗 source link in both vendor tables by adding descriptive `aria-label` and `title` attributes.

## Changes
- `index.md` — add `aria-label` and `title` to source link anchors in both the main list and the Call Us list