### PR TITLE
feat: add client-side vendor name search/filter

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -40,3 +40,19 @@ tr {
 .footnotes {
   font-size: smaller;
 }
+
+#vendor-search {
+  display: block;
+  width: 100%;
+  max-width: 24rem;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.search-empty {
+  color: #999;
+  font-style: italic;
+}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,29 @@
+(function () {
+  function filterTables(query) {
+    var q = query.toLowerCase().trim();
+    var tables = document.querySelectorAll("table.sortable");
+    tables.forEach(function (table) {
+      var rows = table.querySelectorAll("tbody tr");
+      var visible = 0;
+      rows.forEach(function (row) {
+        var nameCell = row.querySelector("td:first-child");
+        if (!nameCell) return;
+        var match = !q || nameCell.textContent.toLowerCase().indexOf(q) !== -1;
+        row.style.display = match ? "" : "none";
+        if (match) visible++;
+      });
+      var empty = table.nextElementSibling;
+      if (empty && empty.classList.contains("search-empty")) {
+        empty.style.display = visible === 0 && q ? "" : "none";
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var input = document.getElementById("vendor-search");
+    if (!input) return;
+    input.addEventListener("input", function () {
+      filterTables(this.value);
+    });
+  });
+})();

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 ---
 <script src="assets/js/sorttable.js"></script>
+<script src="assets/js/search.js"></script>
 
 <details open>
 <summary>
@@ -36,6 +37,8 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 	{% endif %}
 {% endfor %}
 
+<input id="vendor-search" type="search" placeholder="Filter by vendor name…" aria-label="Filter vendors by name">
+
 ## The List
 
 <table class="sortable">
@@ -62,6 +65,7 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 {% endfor %}
 </tbody>
 </table>
+<p class="search-empty" style="display:none">No vendors in this list match your search.</p>
 
 ## The Other List ##
 Some vendors simply do not list their pricing for SSO because the pricing is negotiated with an account manager. These vendors get their own table as we assume they apply a significant premium for SSO.
@@ -90,6 +94,7 @@ Some vendors simply do not list their pricing for SSO because the pricing is neg
 {% endfor %}
 </tbody>
 </table>
+<p class="search-empty" style="display:none">No vendors in this list match your search.</p>
 
 ## FAQs
 


### PR DESCRIPTION
Adds a client-side search input above the vendor tables allowing users to filter vendors by name in real time. No server-side changes required.

## Changes
- `assets/js/search.js` — search/filter logic
- `assets/css/style.scss` — search input styling
- `index.md` — search input UI and script include