### PR TITLE
docs: update CONTRIBUTING and add DEVELOPMENT guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ vendor/
 venv/
 __pycache__/
 .claude/
+TODO.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,14 @@ bundle install
 Then serve the site with:
 
 ```
-bin/serve
+bundle exec jekyll serve
 ```
 
-This wrapper script handles Ruby 4.0+ compatibility (methods removed from stdlib). Do not use `bundle exec jekyll serve` directly — it will fail on Ruby 4.0+.
-
-### Ruby 4.0+ note
-
-If `bundle install` fails with a bundler version error, edit the last line of `Gemfile.lock` from `2.2.27` to your installed bundler version, then re-run. **Do not commit this change** — `Gemfile.lock` must stay pinned to a version compatible with GitHub Pages' Ruby environment.
 ## Call Us
 Vendors whose `sso_pricing` field contains any of the words "call", "contact", "custom", or "quote" (case-insensitive) are automatically sorted into "The Other List" below "The List." Examples: `Call Us!`, `Contact Sales`, `Custom pricing`.
 
 ## Percentages
-A common error with PRs is a miscalculated percentage. The site uses a "percentage increase from base price model" – that is, a $5 -> $10 markup is a 100% increase, not 200%. I'm hoping that a unit test will catch these, but writing a guideline is quicker.
+A common error with PRs is a miscalculated percentage. The site uses a "percentage increase from base price model" – that is, a $5 -> $10 markup is a 100% increase, not 200%. The script that checks PRs will check this math, or will insert the field itself if you don't provide it, as long as the units are consistent.
 
 It's fiddly to get right first time, so here's the convenient formula:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,66 @@
+# Development Guide
+
+## Repo Architecture
+
+**Primary repo:** `robchahin/sso-wall-of-shame` (public, GitHub Pages)
+
+All development happens here. Feature branches, PRs, and merges all target this repo directly. Use **squash-and-merge** for PRs to keep main history clean.
+
+**Scratchpad repo:** `robchahin/sso-integ` (private)
+
+Exists only for testing GitHub Actions workflows that have noisy side effects (opening issues, posting PR comments, auto-committing). Not a development environment. Not kept in sync — force-push from prod when you need a fresh copy:
+
+```bash
+git fetch origin
+git push sso-integ origin/main:main --force
+```
+
+## Local Development
+
+- Ruby 3.4.8 (pinned in `.ruby-version`, managed via `mise`)
+- Python 3 with PyYAML if testing GitHub Actions scripts
+- `bundle exec jekyll serve` to preview locally
+- `vendor/` (used by Bundler) and `venv/` (used by tests) are in both `.gitignore` and `_config.yml` exclude list
+
+## Testing GitHub Actions
+
+### On feature branches (preferred)
+
+Workflows with a `workflow_dispatch` trigger can be tested on any branch via the CLI, even if the workflow doesn't exist on main yet:
+
+```bash
+gh workflow run validate-vendors.yml --ref feat/my-feature
+gh workflow run check-links.yml --ref feat/dead-link-checker
+```
+
+This is the primary way to test workflow changes before merging.
+
+### On sso-integ (for noisy side effects)
+
+If a workflow test will open issues, post comments, or otherwise create visible artifacts, test on sso-integ instead to keep the public repo clean:
+
+```bash
+# Sync sso-integ with current prod state
+git push sso-integ origin/main:main --force
+
+# Push your workflow branch
+git push sso-integ feat/my-workflow:feat/my-workflow
+
+# Trigger from sso-integ
+gh workflow run check-links.yml --repo robchahin/sso-integ --ref feat/my-workflow
+```
+
+### Limitations of workflow_dispatch
+
+`workflow_dispatch` **cannot** retroactively simulate a `pull_request` event. When validate-vendors.yml runs on a PR, it has access to PR context: changed files (via `tj-actions/changed-files`), the PR number for commenting, and the head branch for auto-commits. None of this context exists when triggered via `workflow_dispatch`.
+
+This means you **cannot** use `workflow_dispatch` to run the vendor validation workflow against an old PR that predated the workflow. To validate old PRs, you'd need to either:
+- Re-push the branch (triggers the workflow as a new PR event)
+- Or build dedicated `workflow_dispatch` inputs that accept a PR number and reconstruct the context (not yet implemented)
+
+For workflows that don't depend on PR context (scheduled jobs like the dead link checker), `workflow_dispatch` works identically to the real trigger.
+
+## Branch Naming
+
+- `fix/` — bug fixes
+- `feat/` — new features


### PR DESCRIPTION
## Summary
- **CONTRIBUTING**: removes leftover Ruby 4 shim references (`bin/serve`, Ruby 4.0+ note) that were added erroneously; restores plain `bundle exec jekyll serve` instructions; clarifies that the validation script handles percentage insertion
- **DEVELOPMENT**: new file documenting repo architecture (prod + scratchpad repos), local setup, workflow testing patterns (feature branches vs sso-integ), and branch naming conventions
- **.gitignore**: adds `TODO.md` (local scratchpad file, not meant for version control)

## Test plan
- [x] Confirm `CONTRIBUTING.md` local setup instructions work: `bundle install` + `bundle exec jekyll serve`
- [x] Review `DEVELOPMENT.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)