### PR TITLE
fix: move railway pricing note to footnote

### DIFF
--- a/_vendors/railway.yaml
+++ b/_vendors/railway.yaml
@@ -1,9 +1,9 @@
 ---
 name: Railway
 base_pricing: $20
-sso_pricing: $2000
+sso_pricing: $2000[^railway-sso]
 percent_increase: 9900%
-pricing_note: SSO price only becomes visible when you have already signed up to the Pro plan
+footnotes: '[^railway-sso]: SSO price only becomes visible when you have already signed up to the Pro plan.'
 pricing_source: https://railway.com/pricing
 vendor_url: https://railway.com
 updated_at: 2026-02-18


### PR DESCRIPTION
## Summary
- Moves the Railway `pricing_note` ("SSO price only becomes visible when you have already signed up to the Pro plan") from the inline table cell to a footnote, referenced from `sso_pricing`
- Prevents the long note from breaking the table layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)