### PR TITLE
feat: replace footnotes and pricing_note with info-icon popovers

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-vendor.md
+++ b/.github/ISSUE_TEMPLATE/new-vendor.md
@@ -17,6 +17,7 @@ e.g. $5 per user/month, $3.33 per instance/month
 e.g. $10 per user/month, $6 per instance/month
 
 **Does this pricing info come from a quote or other non-public source?**
-Add any additional pricing context here.
+If yes, we'll add a `pricing_source_info` note next to the source link (e.g. "Pricing comes from a quote").
 
-**Are there any caveats we should list in the footnotes?**
+**Are there any caveats we should add as a vendor note?**
+e.g. "SSO price only becomes visible after signing up to the Pro plan." This will appear as an ⓘ icon next to the vendor name.

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ vendor/
 venv/
 __pycache__/
 .claude/
-TODO.md
+_notes/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,21 @@ A common error with PRs is a miscalculated percentage. The site uses a "percenta
 It's fiddly to get right first time, so here's the convenient formula:
 
 (Higher Price - Lower Price) / Lower Price * 100
+
+## Vendor Notes
+If a vendor's pricing entry needs additional context (e.g. "SSO price only becomes visible after signing up to the Pro plan"), add a `vendor_note` field with a plain-text explanation:
+
+```yaml
+vendor_note: SSO price only becomes visible when you have already signed up to the Pro plan.
+```
+
+This will appear as an ⓘ icon next to the vendor name on the site. Clicking or hovering over it shows the note.
+
+## Pricing Source Info
+If pricing data comes from a non-public source such as a sales quote, add a `pricing_source_info` field:
+
+```yaml
+pricing_source_info: Pricing comes from a quote
+```
+
+This will appear as an ⓘ icon next to the pricing source link. Do not use the old `pricing_note` or `footnotes` fields — these are no longer supported.

--- a/_vendors/airtable.yaml
+++ b/_vendors/airtable.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $10 per u/m
-footnotes: '[^airtable-price]: $60 per user per month, minimum of $3000 per month.'
+vendor_note: $60 per user per month, minimum of $3000 per month.
 name: Airtable
 percent_increase: 500%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://airtable.com/pricing
 sso_pricing: $60 per u/m
 updated_at: 2019-10-19

--- a/_vendors/appsmith.yaml
+++ b/_vendors/appsmith.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $15 per u/m
-footnotes: '[^appsmith-price]: SSO pricing is high due to a 100 user minimum.'
+vendor_note: SSO pricing is high due to a 100 user minimum.
 name: Appsmith
 percent_increase: 16567%
 pricing_source: https://www.appsmith.com/pricing
-sso_pricing: $2500[^appsmith-price]
+sso_pricing: $2500
 updated_at: 2025-06-04
 vendor_url: https://www.appsmith.com

--- a/_vendors/asana.yaml
+++ b/_vendors/asana.yaml
@@ -1,11 +1,10 @@
 ---
 base_pricing: $25 per u/m
-footnotes: '[^asana-price]: Based on business vs. enterprise tier quote; premium is
-  the lower paid tier and would reflect a larger tax.'
+vendor_note: Based on business vs. enterprise tier quote; premium is the lower paid tier and would reflect a larger tax.
 name: Asana
 percent_increase: 140%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://asana.com/pricing
-sso_pricing: $60 per u/m[^asana-price]
+sso_pricing: $60 per u/m
 updated_at: 2020-12-09
 vendor_url: https://asana.com

--- a/_vendors/atlassianjiracloud.yaml
+++ b/_vendors/atlassianjiracloud.yaml
@@ -1,12 +1,9 @@
 ---
 base_pricing: $7.75 per u/m
-footnotes: '[^jira-price]: Hard to compare since Access seems to cover all Atlassian
-  products, so should get cheaper per seat as more products are used - but that doesn''t
-  help people only using Jira. (Jira was chosen as probably the most common Atlassian
-  product.)'
+vendor_note: Hard to compare since Access seems to cover all Atlassian products, so should get cheaper per seat as more products are used - but that doesn't help people only using Jira. (Jira was chosen as probably the most common Atlassian product.)
 name: Atlassian (Jira Cloud)
 percent_increase: 51%
 pricing_source: https://www.atlassian.com/software/access/pricing
-sso_pricing: $11.75 per u/m[^jira-price]
+sso_pricing: $11.75 per u/m
 updated_at: 2023-09-22
 vendor_url: https://www.atlassian.com

--- a/_vendors/backblaze.yaml
+++ b/_vendors/backblaze.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $99 per device/year
-footnotes: '[^backblaze-price]: SSO via Google and Microsoft is included in all product tiers (personal and business) but "OIDC standard authentication including Okta and Azure AD" are only available at the Enterprise Control tier.'
+vendor_note: SSO via Google and Microsoft is included in all product tiers (personal and business) but "OIDC standard authentication including Okta and Azure AD" are only available at the Enterprise Control tier.
 name: Backblaze Computer Backup 
 percent_increase: ???
 pricing_source: https://www.backblaze.com/cloud-backup/pricing
-sso_pricing: Call Us![^backblaze-price]
+sso_pricing: Call Us!
 updated_at: 2025-05-14
 vendor_url: https://www.backblaze.com

--- a/_vendors/breezyhr.yaml
+++ b/_vendors/breezyhr.yaml
@@ -1,10 +1,10 @@
 ---
 base_pricing: $171 per month
-footnotes: '[^breezyhr-price]: SSO is a $1000 per month addon to the Pro plan, which starts at $500 per month.'
+vendor_note: SSO is a $1000 per month addon to the Pro plan, which starts at $500 per month.
 name: Breezy HR
 percent_increase: 777%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://breezy.hr/pricing
-sso_pricing: $1500 per month[^breezyhr-price]
+sso_pricing: $1500 per month
 updated_at: 2023-10-15
 vendor_url: https://breezy.hr

--- a/_vendors/calendly.yaml
+++ b/_vendors/calendly.yaml
@@ -2,7 +2,7 @@
 base_pricing: $12 per u/m
 name: Calendly
 percent_increase: 108%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.calendly.com/pricing
 sso_pricing: $25 per u/m
 updated_at: 2022-03-03

--- a/_vendors/canva.yaml
+++ b/_vendors/canva.yaml
@@ -1,10 +1,10 @@
 ---
-base_pricing: $10 per u/m[^canva]
+base_pricing: $10 per u/m
 name: Canva
-footnotes: '[^canva]: Minimum spend on base tier is $30/month; Minimum spend on SSO is $12,000/year paid upfront.'
-percent_increase: 300%[^canva]
+vendor_note: Minimum spend on base tier is $30/month; Minimum spend on SSO is $12,000/year paid upfront.
+percent_increase: 300%
 pricing_source: https://www.canva.com/pricing/
-sso_pricing: $40 per u/m[^canva]
-pricing_note: Quote
+sso_pricing: $40 per u/m
+pricing_source_info: Pricing comes from a quote
 updated_at: 2024-06-17
 vendor_url: https://canva.com/

--- a/_vendors/coursera.yaml
+++ b/_vendors/coursera.yaml
@@ -2,8 +2,8 @@
 name: Coursera
 url: https://www.coursera.org
 base_pricing: $399 per u/y
-sso_pricing: $49875 per year[^coursera]
-footnotes: '[^coursera]: Coursera requires a minimum of 125 users to access SSO pricing. As they do not have an Enterprise price listed, this price just scales their lower cost tier up to 125 seats.'
+sso_pricing: $49875 per year
+vendor_note: Coursera requires a minimum of 125 users to access SSO pricing. As they do not have an Enterprise price listed, this price just scales their lower cost tier up to 125 seats.
 percent_increase: 12400%
 pricing_source: https://www.coursera.org/business/compare-plans
 updated_at: 2023-10-22

--- a/_vendors/datocms.yaml
+++ b/_vendors/datocms.yaml
@@ -3,7 +3,7 @@ base_pricing: $100 per month
 name: DatoCMS
 percent_increase: 567%
 pricing_source: https://www.datocms.com/pricing
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 sso_pricing: $667 per month
 updated_at: 2023-10-17
 vendor_url: https://datocms.com

--- a/_vendors/docusign.yaml
+++ b/_vendors/docusign.yaml
@@ -2,7 +2,7 @@
 base_pricing: $25 per u/m
 name: DocuSign
 percent_increase: 100%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.docusign.com/products-and-pricing
 sso_pricing: $50 per u/m
 updated_at: 2018-10-17

--- a/_vendors/elastic.yaml
+++ b/_vendors/elastic.yaml
@@ -1,7 +1,6 @@
 ---
-base_pricing: $0.2992[^elastic-note]
-footnotes: '[^elastic-note]: Pricing based on a random small deployment using their
-  pricing calculator.'
+base_pricing: $0.2992
+vendor_note: Pricing based on a random small deployment using their pricing calculator.
 name: Elastic
 percent_increase: 15%
 pricing_source: https://www.elastic.co/subscriptions

--- a/_vendors/genetec.yaml
+++ b/_vendors/genetec.yaml
@@ -1,9 +1,10 @@
 ---
 base_pricing: $99 per connection per year
-footnotes: '[^genetec-price]: Each unique camera/device counts as a connection.'
+vendor_note: Each unique camera/device counts as a connection.
 name: Genetec Video SaaS
 percent_increase: 51%+
 pricing_source: https://www.genetec.com/products/unified-security/security-center-saas/saas-pricing
-sso_pricing: $149 per connection per year[^genetec-price]
+sso_pricing: $149 per connection per year
 updated_at: 2025-08-19
 vendor_url: https://genetec.com
+percent_increase: 51%

--- a/_vendors/gitbook.yaml
+++ b/_vendors/gitbook.yaml
@@ -1,11 +1,9 @@
 ---
 base_pricing: $8 per u/m
-footnotes: '[^gitbook-price]: Google SSO is provided for free, but
-  SAML is only included at the Pro tier. The move from Plus to Pro also
-  adds a fixed $99/mo "platform fee".'
+vendor_note: Google SSO is provided for free, but SAML is only included at the Pro tier. The move from Plus to Pro also adds a fixed $99/mo "platform fee".
 name: GitBook
 percent_increase: 87.5%
 pricing_source: https://www.gitbook.com/pricing
-sso_pricing: $15 per u/m[^gitbook-price]
+sso_pricing: $15 per u/m
 updated_at: 2024-05-09
 vendor_url: https://www.gitbook.com

--- a/_vendors/hootsuite.yaml
+++ b/_vendors/hootsuite.yaml
@@ -2,7 +2,7 @@
 base_pricing: $249/mo
 name: HootSuite
 pricing_source: https://www.hootsuite.com/plans
-sso_pricing: Call Us! (over $249/mo)[^hootsuite]
+sso_pricing: Call Us! (over $249/mo)
 updated_at: 2024-02-09
 vendor_url: https://www.hootsuite.com/
-footnotes: '[^hootsuite]: Only available on Enterprise level plans with "Call Us!" pricing.'
+vendor_note: Only available on Enterprise level plans with "Call Us!" pricing.

--- a/_vendors/hubspotmarketing.yaml
+++ b/_vendors/hubspotmarketing.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $15 per user/month
-footnotes: '[^hubspot-marketing]: SSO pricing is a flat $890/month for 3 users and $50/user/month for additional seats.'
+vendor_note: SSO pricing is a flat $890/month for 3 users and $50/user/month for additional seats.
 name: Hubspot Marketing
 percent_increase: 233%
 pricing_source: https://www.hubspot.com/pricing/marketing
-sso_pricing: $50 per month[^hubspot-marketing]
+sso_pricing: $50 per month
 updated_at: 2025-09-26
 vendor_url: https://www.hubspot.com

--- a/_vendors/jfrog.yaml
+++ b/_vendors/jfrog.yaml
@@ -1,10 +1,9 @@
 ---
 base_pricing: $98/mo
-footnotes: '[^jfrog]: Includes all JFrog products under one license, including Artifactory,
-  Bintray, XRay, etc.'
+vendor_note: Includes all JFrog products under one license, including Artifactory, Bintray, XRay, etc.
 name: JFrog
 percent_increase: 613%
 pricing_source: https://jfrog.com/pricing/
-sso_pricing: $699/mo[^jfrog]
+sso_pricing: $699/mo
 updated_at: 2021-09-06
 vendor_url: https://jfrog.com/

--- a/_vendors/keeperpm.yaml
+++ b/_vendors/keeperpm.yaml
@@ -2,7 +2,7 @@
 base_pricing: $2 per u/m
 name: Keeper Password Manager
 percent_increase: 150%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.keepersecurity.com/pricing/business-and-enterprise.html
 sso_pricing: $5 per u/m
 updated_at: 2023-10-16

--- a/_vendors/later.yaml
+++ b/_vendors/later.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: ???
-footnotes: '[^later-pricing]: Later Influence does not have published pricing but charges a flat $9,999/year to enable SSO. Later Social Media Management is a separate product and includes SSO at all tiers.'
+vendor_note: Later Influence does not have published pricing but charges a flat $9,999/year to enable SSO. Later Social Media Management is a separate product and includes SSO at all tiers.
 name: Later Influence
-percent_increase: ???[^later-pricing]
+percent_increase: ???
 pricing_source: https://help-influence.later.com/hc/en-us/articles/20800757677207-Single-Sign-on-With-Enterprise-Authorization
-sso_pricing: $9,999/year[^later-pricing]
+sso_pricing: $9,999/year
 updated_at: 2025-02-20
 vendor_url: https://later.com/

--- a/_vendors/launchdarkly.yaml
+++ b/_vendors/launchdarkly.yaml
@@ -2,7 +2,7 @@
 base_pricing: $65 per u/m
 name: LaunchDarkly
 percent_increase: 92%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://launchdarkly.com/pricing/
 sso_pricing: $125 per u/m
 updated_at: 2020-01-24

--- a/_vendors/linearb.yaml
+++ b/_vendors/linearb.yaml
@@ -1,9 +1,9 @@
 ---
-base_pricing: $49 per month[^linearb]
+base_pricing: $49 per month
 name: LinearB
 percent_increase: ???
 pricing_source: https://linearb.io/pricing
-footnotes: '[^linearb]: Business pricing starts at $49/month but only includes Social SSO.'
+vendor_note: Business pricing starts at $49/month but only includes Social SSO.
 sso_pricing: Call Us!
 updated_at: 2024-10-16
 vendor_url: https://linearb.io

--- a/_vendors/logrocket.yaml
+++ b/_vendors/logrocket.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $99 per mo
-footnotes: '[^logrocket]: Pricing based on 10k sessions/mo. Monthly per user pricing not included/listed'
+vendor_note: Pricing based on 10k sessions/mo. Monthly per user pricing not included/listed
 name: LogRocket
 percent_increase: 254%
 pricing_source: https://logrocket.com/pricing
-sso_pricing: $350 per mo[^logrocket]
+sso_pricing: $350 per mo
 updated_at: 2024-01-12
 vendor_url: https://logrocket.com/

--- a/_vendors/loom.yaml
+++ b/_vendors/loom.yaml
@@ -2,7 +2,7 @@
 base_pricing: $12.50 per u/m
 name: Loom
 percent_increase: 260%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.loom.com/pricing
 sso_pricing: $45 per u/m
 updated_at: 2023-10-14

--- a/_vendors/lucidchart.yaml
+++ b/_vendors/lucidchart.yaml
@@ -3,7 +3,7 @@ base_pricing: $9 per u/m
 name: Lucidchart
 percent_increase: 122%
 pricing_source: https://lucid.app/pricing/lucidchart
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 sso_pricing: $20 per u/m
 updated_at: 2022-05-24
 vendor_url: https://www.lucidchart.com

--- a/_vendors/metabase.yaml
+++ b/_vendors/metabase.yaml
@@ -1,9 +1,9 @@
 ---
-base_pricing: $85 per month[^metabase]
+base_pricing: $85 per month
 name: Metabase
 percent_increase: 488%
 pricing_source: https://www.metabase.com/pricing/
 sso_pricing: $500 per month
-footnotes: '[^metabase]: Additional 100% increase in monthly user cost ($5->$10) above license increase.'
+vendor_note: Additional 100% increase in monthly user cost ($5->$10) above license increase.
 updated_at: 2024-07-22
 vendor_url: https://www.metabase.com/

--- a/_vendors/mixpanel.yaml
+++ b/_vendors/mixpanel.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $20 per month
-footnotes: '[^mixpanel]: Base plan includes 10K events, whereas SSO-enabled plan (Entreprise) includes 5M events.'
+vendor_note: Base plan includes 10K events, whereas SSO-enabled plan (Entreprise) includes 5M events.
 name: Mixpanel
 percent_increase: 4065%
 pricing_source: https://mixpanel.com/pricing
-sso_pricing: $833 per month[^mixpanel]
+sso_pricing: $833 per month
 updated_at: 2023-10-25
 vendor_url: https://mixpanel.com

--- a/_vendors/mondaycom.yaml
+++ b/_vendors/mondaycom.yaml
@@ -2,7 +2,7 @@
 base_pricing: $7 per u/m
 name: Monday.com
 percent_increase: 286%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://monday.com/pricing/
 sso_pricing: $27 per u/m
 updated_at: 2020-05-26

--- a/_vendors/nationbuilder.yaml
+++ b/_vendors/nationbuilder.yaml
@@ -1,10 +1,8 @@
 ---
 base_pricing: $29 per month
-footnotes: '[^nationbuilder]: To upgrade one plan level is represented by this price
-  increase, but to get single sign-on, you actually have to go up another plan, which
-  is ''Call Us'' pricing.'
+vendor_note: To upgrade one plan level is represented by this price increase, but to get single sign-on, you actually have to go up another plan, which is 'Call Us' pricing.
 name: NationBuilder
-percent_increase: 586%++[^nationbuilder]
+percent_increase: 586%++
 pricing_source: https://nationbuilder.com/pricing
 sso_pricing: Call Us! (over $199/month)
 updated_at: 2019-02-09

--- a/_vendors/newrelicinfrastructure.yaml
+++ b/_vendors/newrelicinfrastructure.yaml
@@ -1,7 +1,6 @@
 ---
-base_pricing: $0.60 - $7.20 per host-month[^newrelic-price]
-footnotes: '[^newrelic-price]: Pricing varies by host size. The SSO cost increase
-  does not.'
+base_pricing: $0.60 - $7.20 per host-month
+vendor_note: Pricing varies by host size. The SSO cost increase does not.
 name: New Relic Infrastructure
 percent_increase: 100%
 pricing_source: https://newrelic.com/products/infrastructure/pricing

--- a/_vendors/onesignal.yaml
+++ b/_vendors/onesignal.yaml
@@ -2,7 +2,7 @@
 base_pricing: $9 per month
 name: OneSignal
 percent_increase: 7307%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://onesignal.com/pricing
 sso_pricing: Call Us! ($8000+ minimum annual commitment)
 updated_at: 2024-08-13

--- a/_vendors/pandadoc.yaml
+++ b/_vendors/pandadoc.yaml
@@ -1,12 +1,10 @@
 ---
 base_pricing: $19 per u/m
-footnotes: '[^pandadoc]: SSO is included with the Enterprise plan for $89 u/m, or
-  can be added to the Business plan for $120 u/y. All prices given require an annual
-  commitment'
+vendor_note: SSO is included with the Enterprise plan for $89 u/m, or can be added to the Business plan for $120 u/y. All prices given require an annual commitment
 name: PandaDoc
 percent_increase: 210%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.pandadoc.com/pricing/
-sso_pricing: $59 per u/m[^pandadoc]
+sso_pricing: $59 per u/m
 updated_at: 2019-10-16
 vendor_url: https://www.pandadoc.com

--- a/_vendors/prismic.yaml
+++ b/_vendors/prismic.yaml
@@ -1,9 +1,9 @@
 ---
-base_pricing: $180 per repository/mo[^prismic]
+base_pricing: $180 per repository/mo
 name: Prismic
 percent_increase: ???
 pricing_source: https://prismic.io/pricing
 sso_pricing: Call us
-footnotes: '[^prismic]: Plan limited to 25 users. Above 25 users price is $750 per repository/mo.'
+vendor_note: Plan limited to 25 users. Above 25 users price is $750 per repository/mo.
 updated_at: 2024-07-26
 vendor_url: https://prismic.io

--- a/_vendors/projectmanager.yaml
+++ b/_vendors/projectmanager.yaml
@@ -3,7 +3,7 @@ base_pricing: $11.50 per u/m
 name: Project Manager
 percent_increase: 291%
 pricing_source: https://www.projectmanager.com/pricing
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 sso_pricing: $45 per u/m
 updated_at: 2022-03-30
 vendor_url: https://www.projectmanager.com/

--- a/_vendors/pulumi.yaml
+++ b/_vendors/pulumi.yaml
@@ -1,9 +1,9 @@
 ---
-base_pricing: $0.1825 per resource/month[^pulumi-notes]
-footnotes: '[^pulumi-notes]: Team plan is $40/month plus $0.1825 per resource, SSO requires Enterprise plan at $400/month plus $0.365 per resource.'
+base_pricing: $0.1825 per resource/month
+vendor_note: Team plan is $40/month plus $0.1825 per resource, SSO requires Enterprise plan at $400/month plus $0.365 per resource.
 name: Pulumi
 percent_increase: 100%
 pricing_source: https://www.pulumi.com/pricing
-sso_pricing: $0.365 per resource/month[^pulumi-notes]
+sso_pricing: $0.365 per resource/month
 updated_at: 2025-09-26
 vendor_url: https://www.pulumi.com

--- a/_vendors/railway.yaml
+++ b/_vendors/railway.yaml
@@ -1,9 +1,9 @@
 ---
 name: Railway
 base_pricing: $20
-sso_pricing: $2000[^railway-sso]
+sso_pricing: $2000
 percent_increase: 9900%
-footnotes: '[^railway-sso]: SSO price only becomes visible when you have already signed up to the Pro plan.'
+vendor_note: SSO price only becomes visible when you have already signed up to the Pro plan.
 pricing_source: https://railway.com/pricing
 vendor_url: https://railway.com
 updated_at: 2026-02-18

--- a/_vendors/raygun.yaml
+++ b/_vendors/raygun.yaml
@@ -1,8 +1,6 @@
 ---
-base_pricing: $79/mo[^raygun]
-footnotes: '[^raygun]: From their SSO tooltip: ''Basic SSO covers social SSO providers
-  only (e.g. Facebook), Advanced SSO includes SAML2 providers (including ActiveDirectory,
-  Auth0, Okta and OneLogin)'''
+base_pricing: $79/mo
+vendor_note: "From their SSO tooltip: 'Basic SSO covers social SSO providers only (e.g. Facebook), Advanced SSO includes SAML2 providers (including ActiveDirectory, Auth0, Okta and OneLogin)'"
 name: Raygun
 percent_increase: 721%
 pricing_source: https://raygun.com/platform/crash-reporting

--- a/_vendors/rollbar.yaml
+++ b/_vendors/rollbar.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $19 per month (25k events)
-footnotes: '[^rollbar]: Basic SSO for Google and GitHub on all plans.  Okta, Azure, etc. are on Advanced plan and up. Increase % varies based on event volume from 105% to 85% at maximum volume'
+vendor_note: Basic SSO for Google and GitHub on all plans.  Okta, Azure, etc. are on Advanced plan and up. Increase % varies based on event volume from 105% to 85% at maximum volume
 name: Rollbar
 percent_increase: 105%
 pricing_source: https://rollbar.com/pricing/
-sso_pricing: $39 per month (25K events)[^rollbar]
+sso_pricing: $39 per month (25K events)
 updated_at: 2024-11-08
 vendor_url: https://rollbar.com/developer/ 

--- a/_vendors/sanity.yaml
+++ b/_vendors/sanity.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $15 per u/m
-footnotes: '[^sanity]: SSO price based on 25 users - SSO is available as an account add on or at the price-unlisted enterprise tier.'
+vendor_note: SSO price based on 25 users - SSO is available as an account add on or at the price-unlisted enterprise tier.
 name: Sanity
 percent_increase: 373%
 pricing_source: https://www.sanity.io/pricing
-sso_pricing: $70.96 per u/m[^sanity]
+sso_pricing: $70.96 per u/m
 updated_at: 2024-01-23
 vendor_url: https://www.sanity.io

--- a/_vendors/sentry.yaml
+++ b/_vendors/sentry.yaml
@@ -1,6 +1,6 @@
 ---
-base_pricing: $26 for 100K events[^sentry]
-footnotes: '[^sentry]: Sentry also provides a self-hosted product in which SSO is included for free.'
+base_pricing: $26 for 100K events
+vendor_note: Sentry also provides a self-hosted product in which SSO is included for free.
 name: Sentry
 percent_increase: 208%
 pricing_source: https://sentry.io/pricing/

--- a/_vendors/shortio.yaml
+++ b/_vendors/shortio.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $48 per month
-footnotes: '[^shortio-price]: Based on Team vs. Enterprise tier pricing.'
+vendor_note: Based on Team vs. Enterprise tier pricing.
 name: Short.io
 percent_increase: 208%
 pricing_source: https://short.io/pricing/
-sso_pricing: $148 per month[^shortio-price]
+sso_pricing: $148 per month
 updated_at: 2025-03-28
 vendor_url: https://short.io/

--- a/_vendors/stackhawk.yaml
+++ b/_vendors/stackhawk.yaml
@@ -1,9 +1,9 @@
 ---
-base_pricing: $42 per u/m[^stackhawk]
-footnotes: '[^stackhawk]: Minimum base pricing is $980/month with minimum SSO pricing of $1,475/month.'
+base_pricing: $42 per u/m
+vendor_note: Minimum base pricing is $980/month with minimum SSO pricing of $1,475/month.
 name: StackHawk
 percent_increase: 40%
 pricing_source: https://www.stackhawk.com/pricing/
-sso_pricing: $59 per u/m[^stackhawk]
+sso_pricing: $59 per u/m
 updated_at: 2025-09-26
 vendor_url: https://www.stackhawk.com/

--- a/_vendors/streamyard.yaml
+++ b/_vendors/streamyard.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $99/mo
 name: StreamYard
-percent_increase: 67%+[^streamyard]
+percent_increase: 67%+
 pricing_source: https://streamyard.com/plan?planType=businesses
 sso_pricing: Call Us! (over $299/mo)
 updated_at: 2024-01-14
 vendor_url: https://www.streamyard.com
-footnotes: '[^streamyard]: Only available on the highest level enterprise plan called "Business", which is ''Call Us!'' pricing.'
+vendor_note: Only available on the highest level enterprise plan called "Business", which is 'Call Us!' pricing.

--- a/_vendors/temporalcloud.yaml
+++ b/_vendors/temporalcloud.yaml
@@ -1,11 +1,12 @@
 ---
-base_pricing: $200 per month[^temporal]
-footnotes: '[^temporal]: Pay-as-you-go based on actions and storage with an additional $200 support fee. SSO requires an additional monthly fee of $200 to $500 depending on users.'
+base_pricing: $200 per month
+vendor_note: Pay-as-you-go based on actions and storage with an additional $200 support fee. SSO requires an additional monthly fee of $200 to $500 depending on users.
 name: Temporal Cloud
 percent_increase: 100%+
 pricing_source:
 - https://temporal.io/pricing
 - https://docs.temporal.io/cloud/pricing#sso-and-saml
-sso_pricing: $400+ per month[^temporal]
+sso_pricing: $400+ per month
 updated_at: 2024-12-27
 vendor_url: https://temporal.io
+percent_increase: 100%

--- a/_vendors/textexpander.yaml
+++ b/_vendors/textexpander.yaml
@@ -1,11 +1,11 @@
 ---
 base_pricing: $8.83 per u/m
 name: TextExpander
-footnotes: '[^textexpander]: While SAML is quoted at $13, SCIM is quoted at $20     - more than the surcharge for SAML.'
+vendor_note: While SAML is quoted at $13, SCIM is quoted at $20     - more than the surcharge for SAML.
 percent_increase: 47%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://textexpander.com/pricing
-sso_pricing: $13 per u/m[^textexpander]
+sso_pricing: $13 per u/m
 updated_at: 2023-10-16
 vendor_url: https://textexpander.com
 

--- a/_vendors/twilio.yaml
+++ b/_vendors/twilio.yaml
@@ -1,10 +1,10 @@
 ---
 name: Twilio
 base_pricing: ???
-footnotes: '[^twilio]: SSO is an a la carte addon available to any account priced at $1,500 per month. Previously, it was sold as part of all three Twilio Editions, starting at $3,500 per month. This is on top of all normal spend.'
+vendor_note: SSO is an a la carte addon available to any account priced at $1,500 per month. Previously, it was sold as part of all three Twilio Editions, starting at $3,500 per month. This is on top of all normal spend.
 percent_increase: ???%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.twilio.com/editions
-sso_pricing: $1500 per month[^twilio]
+sso_pricing: $1500 per month
 updated_at: 2025-08-07
 vendor_url: https://twilio.com

--- a/_vendors/vercel.yaml
+++ b/_vendors/vercel.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $20 per u/m
-footnotes: '[^vercel]: Enterprise for 8 users is "low-to-mid 4 figures", so pricing increase is based on $2000 split 8 ways.'
+vendor_note: Enterprise for 8 users is "low-to-mid 4 figures", so pricing increase is based on $2000 split 8 ways.
 name: Vercel
 percent_increase: 1150%
 pricing_source: https://vercel.com/pricing
-sso_pricing: Call Us![^vercel]
+sso_pricing: Call Us!
 updated_at: 2023-10-17
 vendor_url: https://vercel.com

--- a/_vendors/victorops.yaml
+++ b/_vendors/victorops.yaml
@@ -1,9 +1,9 @@
 ---
 base_pricing: $29 per u/m
-footnotes: '[^victorops]: You can add SSO to a plan for $5 per u/m'
+vendor_note: You can add SSO to a plan for $5 per u/m
 name: VictorOps
 percent_increase: 69%
 pricing_source: https://victorops.com/pricing
-sso_pricing: $49 per u/m[^victorops]
+sso_pricing: $49 per u/m
 updated_at: 2018-10-17
 vendor_url: https://victorops.com

--- a/_vendors/wedo.yaml
+++ b/_vendors/wedo.yaml
@@ -1,9 +1,7 @@
 ---
 base_pricing: $19.90 per u/m
-footnotes: 
 name: Wedo
 percent_increase: 25.13%
-pricing_note: 
 pricing_source: https://wedo.com/de/pricing
 sso_pricing: $24.90 per u/m
 updated_at: 2026-02-03

--- a/_vendors/wix.yaml
+++ b/_vendors/wix.yaml
@@ -2,7 +2,7 @@
 base_pricing: $36 per month
 name: Wix
 percent_increase: 1289%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://www.wix.com/plans
 sso_pricing: $500 per month
 updated_at: 2024-09-05

--- a/_vendors/writesonic.yaml
+++ b/_vendors/writesonic.yaml
@@ -1,12 +1,10 @@
 ---
 base_pricing: $199 per u/m
-footnotes: '[^writesonic-price]: Writesonic has with multiple products and
-  pricing models. Starting at $1500 per month is the Enterprise plan, which is the only
-  one that includes SSO. The $199 per u/m is for the Professional plan - lowest non-individual targeted plan.'
+vendor_note: Writesonic has with multiple products and pricing models. Starting at $1500 per month is the Enterprise plan, which is the only one that includes SSO. The $199 per u/m is for the Professional plan - lowest non-individual targeted plan.
 name: Writesonic
 percent_increase: 654%
-pricing_note: Quote
+pricing_source_info: Pricing comes from a quote
 pricing_source: https://writesonic.com/pricing
-sso_pricing: $1500[^writesonic-price]
+sso_pricing: $1500
 updated_at: 2025-09-26
 vendor_url: https://writesonic.com

--- a/_vendors/zeplin.yaml
+++ b/_vendors/zeplin.yaml
@@ -1,10 +1,9 @@
 ---
 base_pricing: $10.75 per u/m
-footnotes: '[^zeplin]: Also requires paying for a minimum of 50 seats, compared to
-  12 with the Business plan'
+vendor_note: Also requires paying for a minimum of 50 seats, compared to 12 with the Business plan
 name: Zeplin
 percent_increase: 100%
 pricing_source: Quote
-sso_pricing: $21.50 per u/m[^zeplin]
+sso_pricing: $21.50 per u/m
 updated_at: 2021-01-06
 vendor_url: https://zeplin.io/

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -37,8 +37,35 @@ tr {
   }
 }
 
-.footnotes {
-  font-size: smaller;
+.info-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #666;
+  padding: 0 0.2rem;
+  vertical-align: middle;
+  line-height: 1;
+
+  &:hover,
+  &:focus {
+    color: #159957;
+    outline: none;
+  }
+}
+
+.info-popover {
+  position: absolute;
+  z-index: 100;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  max-width: 300px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  white-space: normal;
 }
 
 #vendor-search {

--- a/assets/js/popover.js
+++ b/assets/js/popover.js
@@ -1,0 +1,95 @@
+(function () {
+  var openPopover = null;
+  var openButton = null;
+  var hoverTimer = null;
+  var popoverCounter = 0;
+
+  function closePopover() {
+    if (openPopover) {
+      openPopover.remove();
+      openPopover = null;
+    }
+    if (openButton) {
+      openButton.setAttribute('aria-expanded', 'false');
+      openButton.removeAttribute('aria-describedby');
+      openButton = null;
+    }
+  }
+
+  function showPopover(btn) {
+    closePopover();
+
+    var note = btn.getAttribute('data-note');
+    if (!note) return;
+
+    var id = 'info-popover-' + (++popoverCounter);
+    var pop = document.createElement('div');
+    pop.className = 'info-popover';
+    pop.id = id;
+    pop.setAttribute('role', 'tooltip');
+    pop.textContent = note;
+
+    // Position relative to the document, anchored below-right of the button
+    document.body.appendChild(pop);
+    var rect = btn.getBoundingClientRect();
+    var scrollX = window.pageXOffset || document.documentElement.scrollLeft;
+    var scrollY = window.pageYOffset || document.documentElement.scrollTop;
+    pop.style.left = (rect.left + scrollX) + 'px';
+    pop.style.top = (rect.bottom + scrollY + 4) + 'px';
+
+    btn.setAttribute('aria-expanded', 'true');
+    btn.setAttribute('aria-describedby', id);
+
+    openPopover = pop;
+    openButton = btn;
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // Delegated click: toggle popover on button click
+    document.addEventListener('click', function (e) {
+      var btn = e.target.closest('.info-toggle');
+      if (btn) {
+        e.stopPropagation();
+        if (openButton === btn) {
+          closePopover();
+        } else {
+          showPopover(btn);
+        }
+        return;
+      }
+      // Click outside closes any open popover
+      closePopover();
+    });
+
+    // Escape key closes popover
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        closePopover();
+      }
+    });
+
+    // Hover: show on mouseenter, hide on mouseleave (with small delay to allow
+    // moving the cursor from button to popover without it closing)
+    document.addEventListener('mouseover', function (e) {
+      var btn = e.target.closest('.info-toggle');
+      if (btn) {
+        clearTimeout(hoverTimer);
+        if (openButton !== btn) {
+          showPopover(btn);
+        }
+      }
+    });
+
+    document.addEventListener('mouseout', function (e) {
+      var btn = e.target.closest('.info-toggle');
+      if (btn) {
+        hoverTimer = setTimeout(function () {
+          // Only close if the cursor didn't move to the popover
+          if (openPopover && !openPopover.matches(':hover')) {
+            closePopover();
+          }
+        }, 150);
+      }
+    });
+  });
+})();

--- a/index.md
+++ b/index.md
@@ -2,6 +2,7 @@
 ---
 <script src="assets/js/sort.js"></script>
 <script src="assets/js/search.js"></script>
+<script src="assets/js/popover.js"></script>
 
 <details open>
 <summary>
@@ -49,7 +50,7 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 <tbody>
 {% for vendor in vendors %}
 <tr>
-<td markdown="span"><a href="{{ vendor.vendor_url }}">{{ vendor.name }}</a></td>
+<td markdown="span"><a href="{{ vendor.vendor_url }}">{{ vendor.name }}</a>{% if vendor.vendor_note %} <button class="info-toggle" aria-label="Note about {{ vendor.name }}" data-note="{{ vendor.vendor_note | escape }}">&#9432;</button>{% endif %}</td>
 <td markdown="span">{{ vendor.base_pricing }}</td>
 <td markdown="span">{{ vendor.sso_pricing }}</td>
 <td markdown="span">{{ vendor.percent_increase }}</td>
@@ -60,7 +61,7 @@ Many vendors charge 2x, 3x, or 4x the base product pricing for access to SSO, wh
 {% endif %}
 <a href="{{ source }}" aria-label="Pricing source for {{ vendor.name }}" title="Pricing source for {{ vendor.name }}">&#128279;</a>
 {% endfor %}
-{{ vendor.pricing_note }}</td>
+{% if vendor.pricing_source_info %}<button class="info-toggle" aria-label="Source info for {{ vendor.name }}" data-note="{{ vendor.pricing_source_info | escape }}">&#9432;</button>{% endif %}</td>
 <td>{{ vendor.updated_at }}</td>
 </tr>
 {% endfor %}
@@ -78,7 +79,7 @@ Some vendors simply do not list their pricing for SSO because the pricing is neg
 <tbody>
 {% for vendor in call_us %}
 <tr>
-<td markdown="span"><a href="{{ vendor.vendor_url }}">{{ vendor.name }}</a></td>
+<td markdown="span"><a href="{{ vendor.vendor_url }}">{{ vendor.name }}</a>{% if vendor.vendor_note %} <button class="info-toggle" aria-label="Note about {{ vendor.name }}" data-note="{{ vendor.vendor_note | escape }}">&#9432;</button>{% endif %}</td>
 <td markdown="span">{{ vendor.base_pricing }}</td>
 <td markdown="span">{{ vendor.sso_pricing }}</td>
 <td markdown="span">{{ vendor.percent_increase }}</td>
@@ -89,7 +90,7 @@ Some vendors simply do not list their pricing for SSO because the pricing is neg
 {% endif %}
 <a href="{{ source }}" aria-label="Pricing source for {{ vendor.name }}" title="Pricing source for {{ vendor.name }}">&#128279;</a>
 {% endfor %}
-{{ vendor.pricing_note }}</td>
+{% if vendor.pricing_source_info %}<button class="info-toggle" aria-label="Source info for {{ vendor.name }}" data-note="{{ vendor.pricing_source_info | escape }}">&#9432;</button>{% endif %}</td>
 <td>{{ vendor.updated_at }}</td>
 </tr>
 {% endfor %}
@@ -115,9 +116,9 @@ We disregard free tier pricing, as we can assume these aren't intended for long 
 
 <details>
 <summary>
-What does "Quote" mean in the Source column?
+What does the ⓘ icon next to a source mean?
 </summary>
-If a vendor doesn't list pricing but a user has submitted pricing based on a quote, it can be included here. If a vendor feels that their actual pricing is inaccurately reflected by this quote, feel free to let me know and I'll update the page.
+If a vendor doesn't publicly list their SSO pricing but a user has submitted pricing based on a quote or other non-public source, a note will be shown next to the source link. If a vendor feels that their actual pricing is inaccurately reflected, feel free to let me know and I'll update the page.
 </details>
 
 <details>
@@ -141,10 +142,3 @@ But it costs money to provide SAML support, so we can't offer it for free!
   While I'd like people to really consider it a <em>bare minimum</em> feature for business SaaS, I'm OK with it costing a little extra to cover maintenance costs. If your SSO support is a 10% price hike, you're not on this list. But these percentage increases are not maintenance costs, they're revenue generation because you know your customers have no good options.
 </details>
 
-## Footnotes
-{% for vendor in vendors %}
-{{ vendor.footnotes }}
-{% endfor %}
-{% for vendor in call_us %}
-{{ vendor.footnotes }}
-{% endfor %}

--- a/scripts/migrate_footnotes.py
+++ b/scripts/migrate_footnotes.py
@@ -1,0 +1,125 @@
+"""
+One-time migration script: replace footnotes and pricing_note fields.
+
+- `footnotes: '[^id]: text'` → `vendor_note: text`
+  Strips [^id] references from sso_pricing, base_pricing, percent_increase.
+- `pricing_note: Quote` → `pricing_source_info: Pricing comes from a quote`
+  Empty pricing_note fields are removed.
+
+Run from the repo root:
+  python3 scripts/migrate_footnotes.py
+"""
+
+import os
+import re
+
+VENDORS_DIR = os.path.join(os.path.dirname(__file__), '..', '_vendors')
+
+# Matches a footnote definition prefix like "[^some-id]: "
+FOOTNOTE_DEF_RE = re.compile(r'^\[\^[^\]]+\]:\s*')
+
+# Matches any footnote reference like "[^some-id]"
+FOOTNOTE_REF_RE = re.compile(r'\[\^[^\]]+\]')
+
+
+def migrate_file(path):
+    with open(path, 'r') as f:
+        original = f.read()
+
+    lines = original.splitlines(keepends=True)
+    new_lines = []
+    i = 0
+    changed = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        # --- footnotes field ---
+        if re.match(r'^footnotes:\s*', line):
+            # Collect the full value (may be multi-line YAML block scalar)
+            raw_value_lines = [line]
+            j = i + 1
+            while j < len(lines) and lines[j] and lines[j][0] in (' ', '\t'):
+                raw_value_lines.append(lines[j])
+                j += 1
+
+            # Extract the value portion from first line
+            first = re.sub(r'^footnotes:\s*', '', raw_value_lines[0]).rstrip('\n')
+
+            # Join continuation lines with a space (preserving word boundaries)
+            rest_parts = [l.strip() for l in raw_value_lines[1:]]
+            combined = (first + ' ' + ' '.join(rest_parts)).strip()
+
+            # Remove surrounding single or double quotes
+            if len(combined) >= 2 and combined[0] == combined[-1] and combined[0] in ('"', "'"):
+                combined = combined[1:-1]
+
+            # Handle YAML escaped single quotes ('') → (')
+            combined = combined.replace("''", "'")
+
+            # Strip the "[^id]: " prefix to get the note text
+            note_text = FOOTNOTE_DEF_RE.sub('', combined).strip()
+
+            if note_text:
+                # Quote the value if it contains characters that would break plain YAML
+                if "'" in note_text or ':' in note_text or '#' in note_text:
+                    escaped = note_text.replace('"', '\\"')
+                    new_lines.append(f'vendor_note: "{escaped}"\n')
+                else:
+                    new_lines.append(f'vendor_note: {note_text}\n')
+
+            # Always mark changed so the file is rewritten (old field is dropped either way)
+            changed = True
+            i = j
+            continue
+
+        # --- pricing_note field ---
+        if re.match(r'^pricing_note:\s*', line):
+            value = re.sub(r'^pricing_note:\s*', '', line).strip()
+            if value:
+                if value.lower() == 'quote':
+                    new_lines.append('pricing_source_info: Pricing comes from a quote\n')
+                else:
+                    new_lines.append(f'pricing_source_info: {value}\n')
+            # Drop the field (renamed or empty); always mark changed
+            changed = True
+            i += 1
+            continue
+
+        # --- pricing fields: strip [^ref] references ---
+        if re.match(r'^(sso_pricing|base_pricing|percent_increase):\s*', line):
+            new_line, n = FOOTNOTE_REF_RE.subn('', line)
+            if n > 0:
+                new_lines.append(new_line)
+                changed = True
+            else:
+                new_lines.append(line)
+            i += 1
+            continue
+
+        new_lines.append(line)
+        i += 1
+
+    if changed:
+        with open(path, 'w') as f:
+            f.writelines(new_lines)
+        return True
+    return False
+
+
+def main():
+    vendors_dir = os.path.abspath(VENDORS_DIR)
+    files = sorted(f for f in os.listdir(vendors_dir) if f.endswith(('.yaml', '.yml')))
+
+    migrated = 0
+    for filename in files:
+        path = os.path.join(vendors_dir, filename)
+        if migrate_file(path):
+            print(f'  migrated: {filename}')
+            migrated += 1
+
+    print(f'\nDone. {migrated}/{len(files)} files updated.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Replaces the error-prone `footnotes`/`[^ref]` Markdown syntax with a plain-text `vendor_note` field, rendered as an ⓘ icon popover next to the vendor name
- Replaces `pricing_note` with `pricing_source_info`, rendered as an ⓘ icon popover next to the pricing source link
- Migrates all 51 affected vendor YAML files via `scripts/migrate_footnotes.py`
- Adds `assets/js/popover.js`: click/hover popovers, keyboard accessible (`aria-expanded`, `aria-describedby`, Escape to close)
- Removes the Footnotes section from `index.md`
- Updates `validate_pricing.py`: new fields are known, old fields emit targeted deprecation warnings (not generic unknown-field warnings), and legacy `[^ref]` syntax is stripped before percentage checks for old-format PRs
- Updates CONTRIBUTING.md and issue template for new fields

## Test plan

- [ ] Verify popovers render and dismiss correctly on desktop (click, hover, Escape key)
- [ ] Verify popovers are accessible (keyboard navigation, aria attributes)
- [ ] Verify no footnote section appears at bottom of page
- [ ] Verify validation passes on all vendor files (`python3 -m pytest tests/`)
- [ ] Verify old `footnotes`/`pricing_note` fields emit deprecation warnings (not unknown-field errors) in validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)