### PR TITLE
fix: downgrade pricing_source non-URL from error to warning

### DIFF
--- a/scripts/validate_pricing.py
+++ b/scripts/validate_pricing.py
@@ -121,13 +121,19 @@ def validate_schema(data, warnings, errors):
     if vendor_url and not _is_valid_url(vendor_url):
         errors.append(f"'vendor_url' does not look like a valid URL: '{vendor_url}'.")
 
-    # pricing_source can be a string or list; each entry must look like a URL
+    # pricing_source can be a string or list; each entry should look like a URL.
+    # Non-URL values are a warning rather than an error — maintainers may approve
+    # exceptions where a direct URL is not available (e.g. pricing via sales quote).
     pricing_source = data.get('pricing_source')
     if pricing_source:
         sources = pricing_source if isinstance(pricing_source, list) else [pricing_source]
         for src in sources:
             if not _is_valid_url(src):
-                errors.append(f"'pricing_source' entry does not look like a valid URL: '{src}'.")
+                warnings.append(
+                    f"'pricing_source' does not look like a valid URL: '{src}'. "
+                    f"Please provide a direct link to the pricing page wherever possible; "
+                    f"maintainers may approve exceptions where no URL is available."
+                )
 
 
 def validate_vendor_file(filepath):

--- a/tests/test_validate_pricing.py
+++ b/tests/test_validate_pricing.py
@@ -78,7 +78,8 @@ class TestValidateSchema(unittest.TestCase):
         data['pricing_source'] = 'not-a-url'
         warnings, errors = [], []
         validate_schema(data, warnings, errors)
-        self.assertTrue(any("pricing_source" in e for e in errors))
+        self.assertEqual(errors, [])
+        self.assertTrue(any("pricing_source" in w for w in warnings))
 
     def test_pricing_source_list(self):
         data = self._make_valid_data()


### PR DESCRIPTION
## Summary

`pricing_source` entries that aren't valid URLs were previously blocking errors. This changes them to warnings, since contributors may legitimately lack a direct URL (e.g. pricing obtained via sales quote). The warning message asks for a URL wherever possible and notes that maintainers may approve exceptions.

Addresses the known case of `_vendors/zeplin.yaml` (`pricing_source: Quote`) and the three vendors with empty `pricing_source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)