### PR TITLE
fix: granular validation labels with noise-free label management

### DIFF
--- a/.github/workflows/validate-vendors.yml
+++ b/.github/workflows/validate-vendors.yml
@@ -147,17 +147,27 @@ jobs:
           # These map to predefined labels — never derived from free-text PR content.
           HAS_SCHEMA_ERROR=false
           HAS_PRICING_ERROR=false
+          HAS_SCHEMA_WARNING=false
+          HAS_PRICING_WARNING=false
           if grep -q "CATEGORY:schema-error" validation_output.txt; then
             HAS_SCHEMA_ERROR=true
           fi
           if grep -q "CATEGORY:pricing-error" validation_output.txt; then
             HAS_PRICING_ERROR=true
           fi
+          if grep -q "CATEGORY:schema-warning" validation_output.txt; then
+            HAS_SCHEMA_WARNING=true
+          fi
+          if grep -q "CATEGORY:pricing-warning" validation_output.txt; then
+            HAS_PRICING_WARNING=true
+          fi
 
           echo "has_errors=$HAS_ERRORS" >> $GITHUB_OUTPUT
           echo "has_warnings=$HAS_WARNINGS" >> $GITHUB_OUTPUT
           echo "has_schema_error=$HAS_SCHEMA_ERROR" >> $GITHUB_OUTPUT
           echo "has_pricing_error=$HAS_PRICING_ERROR" >> $GITHUB_OUTPUT
+          echo "has_schema_warning=$HAS_SCHEMA_WARNING" >> $GITHUB_OUTPUT
+          echo "has_pricing_warning=$HAS_PRICING_WARNING" >> $GITHUB_OUTPUT
 
           # Build a PR comment if there are errors or warnings
           if [ "$HAS_ERRORS" = "true" ] || [ "$HAS_WARNINGS" = "true" ]; then
@@ -186,46 +196,59 @@ jobs:
         if: steps.changed-vendors.outputs.any_changed == 'true'
         with:
           script: |
-            const prNumber = ${{ steps.pr-context.outputs.pr_number }};
-            const hasErrors = '${{ steps.validate.outputs.has_errors }}' === 'true';
-            const hasSchemaError = '${{ steps.validate.outputs.has_schema_error }}' === 'true';
-            const hasPricingError = '${{ steps.validate.outputs.has_pricing_error }}' === 'true';
+            const prNumber        = ${{ steps.pr-context.outputs.pr_number }};
+            const hasErrors       = '${{ steps.validate.outputs.has_errors }}'         === 'true';
+            const hasWarnings     = '${{ steps.validate.outputs.has_warnings }}'       === 'true';
+            const hasSchemaError  = '${{ steps.validate.outputs.has_schema_error }}'   === 'true';
+            const hasPricingError = '${{ steps.validate.outputs.has_pricing_error }}'  === 'true';
+            const hasSchemaWarn   = '${{ steps.validate.outputs.has_schema_warning }}' === 'true';
+            const hasPricingWarn  = '${{ steps.validate.outputs.has_pricing_warning }}' === 'true';
 
-            const validationLabels = [
+            const allValidationLabels = [
               'validation: schema error',
               'validation: pricing error',
+              'validation: schema warning',
+              'validation: pricing warning',
               'validation: passed',
             ];
 
-            // Remove all existing validation labels so re-pushed PRs get a clean slate
-            const currentLabels = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-            for (const label of currentLabels.data) {
-              if (validationLabels.includes(label.name)) {
+            // Build the desired label set
+            const desired = new Set();
+            if (hasSchemaError)  desired.add('validation: schema error');
+            if (hasPricingError) desired.add('validation: pricing error');
+            if (hasSchemaWarn)   desired.add('validation: schema warning');
+            if (hasPricingWarn)  desired.add('validation: pricing warning');
+            if (!hasErrors && !hasWarnings) desired.add('validation: passed');
+
+            // Fetch current labels on the PR
+            const current = new Set(
+              (await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              })).data.map(l => l.name)
+            );
+
+            // Only remove validation labels that are no longer wanted
+            for (const label of allValidationLabels) {
+              if (current.has(label) && !desired.has(label)) {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  name: label.name,
+                  name: label,
                 }).catch(() => {});
               }
             }
 
-            // Apply the appropriate labels
-            const labelsToAdd = [];
-            if (hasSchemaError) labelsToAdd.push('validation: schema error');
-            if (hasPricingError) labelsToAdd.push('validation: pricing error');
-            if (!hasErrors) labelsToAdd.push('validation: passed');
-
-            if (labelsToAdd.length > 0) {
+            // Only add labels not already present
+            const toAdd = [...desired].filter(l => !current.has(l));
+            if (toAdd.length > 0) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                labels: labelsToAdd,
+                labels: toAdd,
               });
             }
 

--- a/scripts/validate_pricing.py
+++ b/scripts/validate_pricing.py
@@ -289,15 +289,20 @@ def main():
                 print(f"   Warning: {warning}")
 
     # Emit machine-readable category markers for the workflow to map to PR labels.
-    # These are derived from error messages using stable keyword matches — never
+    # These are derived from message text using stable keyword matches — never
     # from free-text that could be influenced by PR content.
     categories = set()
-    for errors, _ in results.values():
+    for errors, warnings in results.values():
         for e in errors:
-            if any(k in e for k in ["Missing required field", "not a valid", "Unknown field", "Duplicate", "Empty YAML", "Failed to parse", "Failed to read"]):
+            if any(k in e for k in ["Missing required field", "not a valid", "Duplicate", "Empty YAML", "Failed to parse", "Failed to read"]):
                 categories.add("CATEGORY:schema-error")
             if any(k in e for k in ["percent_increase", "Percentage mismatch"]):
                 categories.add("CATEGORY:pricing-error")
+        for w in warnings:
+            if any(k in w for k in ["deprecated", "Unknown field", "pricing_source"]):
+                categories.add("CATEGORY:schema-warning")
+            if any(k in w for k in ["units appear to differ", "Could not extract", "Contact Us", "Base pricing is $0", "percent_increase"]):
+                categories.add("CATEGORY:pricing-warning")
     for cat in sorted(categories):
         print(cat)
 


### PR DESCRIPTION
## Summary

- Adds `validation: schema warning` and `validation: pricing warning` labels for the warnings-only case, fixing the bug where warnings-only PRs received `validation: passed`
- `validation: passed` is now only applied when the validator comes back completely clean
- Label management now diffs current vs desired state and only removes/adds where needed, eliminating spurious add/remove events in the PR timeline
- `validate_pricing.py` emits `CATEGORY:schema-warning` and `CATEGORY:pricing-warning` markers alongside the existing error markers

## Label inventory

| Label | When applied |
|-------|-------------|
| `validation: schema error` | Missing/invalid fields, parse failures, duplicate keys |
| `validation: pricing error` | Missing or wrong `percent_increase` |
| `validation: schema warning` | Deprecated fields, unknown fields, non-URL `pricing_source` |
| `validation: pricing warning` | Unit mismatch, unextractable prices |
| `validation: passed` | Validator completely clean — no errors, no warnings |

A PR can carry multiple labels (e.g. `schema warning` + `pricing error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)