### PR TITLE
Delete _vendors/hotjar.yaml

### DIFF
--- a/_vendors/hotjar.yaml
+++ b/_vendors/hotjar.yaml
@@ -1,8 +1,0 @@
----
-base_pricing: $39 per month
-name: Hotjar Observe
-percent_increase: 446%
-pricing_source: https://www.hotjar.com/pricing/
-sso_pricing: $213 per moth
-updated_at: 2023-10-17
-vendor_url: https://www.hotjar.com


### PR DESCRIPTION
Came to fix the typo, as much as I like the idea of "per moth" pricing, but found out Hotjar has been absorbed into something called ContentSquare which barely lists any products and certainly doesn't list any pricing, so can't really keep them on the list.