### PR TITLE
docs: rewrite README, restructure CONTRIBUTING, fix stale DEVELOPMENT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,100 @@
-# sso.tax Contributing Guidelines
+# Contributing to sso.tax
 
-## Running Locally
+## Quick start: adding a vendor
 
-Requires Ruby and Bundler. Install dependencies with:
+1. Create `_vendors/yourvendor.yaml` (lowercase, hyphens instead of spaces)
+2. Copy the template below and fill it in
+3. Open a PR — the validation bot will check your submission automatically
 
-```
-bundle install
-```
-
-Then serve the site with:
-
-```
-bundle exec jekyll serve
-```
-
-## Call Us
-Vendors whose `sso_pricing` field contains any of the words "call", "contact", "custom", or "quote" (case-insensitive) are automatically sorted into "The Other List" below "The List." Examples: `Call Us!`, `Contact Sales`, `Custom pricing`.
-
-## Percentages
-A common error with PRs is a miscalculated percentage. The site uses a "percentage increase from base price model" – that is, a $5 -> $10 markup is a 100% increase, not 200%. The script that checks PRs will check this math, or will insert the field itself if you don't provide it, as long as the units are consistent.
-
-It's fiddly to get right first time, so here's the convenient formula:
-
-(Higher Price - Lower Price) / Lower Price * 100
-
-## Vendor Notes
-If a vendor's pricing entry needs additional context (e.g. "SSO price only becomes visible after signing up to the Pro plan"), add a `vendor_note` field with a plain-text explanation:
+## Vendor YAML template
 
 ```yaml
-vendor_note: SSO price only becomes visible when you have already signed up to the Pro plan.
+---
+name: Example Vendor
+base_pricing: $10 per user/month
+sso_pricing: $25 per user/month
+percent_increase: 150%
+vendor_url: https://example.com
+pricing_source: https://example.com/pricing
+updated_at: 2024-01-15
+# Optional fields — include only if relevant:
+# vendor_note: SSO requires the Enterprise plan, which bundles other features.
+# pricing_source_info: Pricing comes from a quote
 ```
 
-This will appear as an ⓘ icon next to the vendor name on the site. Clicking or hovering over it shows the note.
+## Field reference
 
-## Pricing Source Info
-If pricing data comes from a non-public source such as a sales quote, add a `pricing_source_info` field:
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Vendor's display name |
+| `base_pricing` | Yes | Lowest reasonable business-tier price (not free/personal tiers) |
+| `sso_pricing` | Yes | Cheapest tier that includes SSO. Use `Call Us!` if not publicly listed. |
+| `percent_increase` | Yes* | `(sso - base) / base * 100`. The validator will tell you the correct value if you get it wrong. |
+| `vendor_url` | Yes | Vendor's homepage URL |
+| `pricing_source` | Yes | Direct link to the pricing page. Can be a list of URLs. Non-URL values (e.g. `Quote`) are accepted but discouraged. |
+| `updated_at` | Yes | Date pricing was last verified, in `YYYY-MM-DD` format |
+| `vendor_note` | No | Context shown as an info icon next to the vendor name (plain text) |
+| `pricing_source_info` | No | Context shown as an info icon next to the source link (e.g. `Pricing comes from a quote`) |
+
+\* If you omit `percent_increase` and both prices are parseable, the validator will calculate it for you and tell you what to add.
+
+## Calculating the percentage
+
+The site uses a "percentage increase from base price" model:
+
+**(SSO price - Base price) / Base price * 100**
+
+A $5 to $10 markup is a **100%** increase, not 50%. The validator checks this math and will flag mismatches.
+
+Make sure `base_pricing` and `sso_pricing` use the same units (e.g. both "per user/month"). The bot will warn if the units don't match — it's not blocking, but mismatched units usually mean the percentage is comparing apples to oranges.
+
+## "Call Us" vendors
+
+If the vendor doesn't publish SSO pricing, set `sso_pricing` to something like `Call Us!`, `Contact Sales`, or `Custom pricing`. The site detects the keywords *call*, *contact*, *custom*, and *quote* (case-insensitive) and sorts these vendors into "The Other List" instead of the main table.
+
+## Vendor notes and pricing source info
+
+Use `vendor_note` when a vendor's pricing entry needs context that isn't obvious from the numbers alone:
+
+```yaml
+vendor_note: SSO requires the Enterprise plan, which bundles other features.
+```
+
+This appears as an info icon next to the vendor name on the site.
+
+Use `pricing_source_info` when pricing data comes from a non-public source:
 
 ```yaml
 pricing_source_info: Pricing comes from a quote
 ```
 
-This will appear as an ⓘ icon next to the pricing source link. Do not use the old `pricing_note` or `footnotes` fields — these are no longer supported.
+This appears as an info icon next to the pricing source link.
+
+## What the validation bot does
+
+When you open a PR that changes files in `_vendors/`, the bot automatically:
+
+- **Checks schema**: required fields present, valid date format, valid URLs
+- **Validates percentage math**: compares your `percent_increase` against the calculated value
+- **Flags deprecated fields**: the old `footnotes` and `pricing_note` fields are no longer supported
+- **Labels the PR**: with specific labels like `validation: passed`, `validation: schema error`, etc.
+
+**Errors** must be fixed before merging. **Warnings** are flagged for maintainer review but won't block the PR.
+
+## Running locally
+
+This is optional — the validation bot and GitHub Pages preview will catch most issues.
+
+Requires Ruby (version pinned in `.ruby-version`) and Bundler. Use a version manager like [mise](https://mise.jdx.dev/) or [rbenv](https://github.com/rbenv/rbenv) to pick up the correct version automatically:
+
+```
+mise install        # or: rbenv install
+bundle install
+bundle exec jekyll serve
+```
+
+To run the validator locally:
+
+```
+python3 scripts/validate_pricing.py _vendors/yourvendor.yaml
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# sso-wall-of-shame
+# sso.tax
 
-A list of vendors that treat single sign-on as a luxury feature, not a core security requirement.
+A community-maintained list of vendors that charge extra for SSO (single sign-on). The live site is at **[sso.tax](https://sso.tax)**.
 
-Page structure lives in index.md, including intro text and FAQs for now.
+## How it works
 
-Vendor data lives in `_vendors/`.
+Each vendor is a YAML file in `_vendors/`. Jekyll builds the site and deploys to GitHub Pages on every push to main. Vendors are sorted into two tables: **The List** (vendors with published SSO pricing, sorted by markup percentage) and **The Other List** (vendors that require contacting sales).
+
+## Contributing
+
+Know a vendor that charges extra for SSO? Add a YAML file and open a PR — a validation bot will check your submission automatically. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide and YAML template.
+
+## For maintainers
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for repo architecture, testing workflows, and branch conventions.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- **README.md**: Full rewrite — sso.tax branding, concise description of how the repo works, links to CONTRIBUTING and DEVELOPMENT
- **CONTRIBUTING.md**: Restructured as a step-by-step guide for adding a vendor — copy-paste YAML template, field reference table, percentage formula, "Call Us" explanation, unit mismatch guidance, what the validation bot does, and local setup with Ruby version manager instructions
- **DEVELOPMENT.md**: Replaced stale "Limitations of workflow_dispatch" section (referenced tj-actions and said dispatch couldn't validate old PRs) with accurate docs for the current `workflow_dispatch` PR validation feature; clarified Ruby version manager requirement

## Test plan
- [x] Sample YAML template from CONTRIBUTING passes `validate_pricing.py` cleanly
- [x] All 37 unit tests pass
- [x] Review rendered markdown on GitHub for readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)