### PR TITLE
Add Testmo

### DIFF
--- a/_vendors/testmo.yaml
+++ b/_vendors/testmo.yaml
@@ -1,0 +1,9 @@
+---
+name: Testmo
+base_pricing: $329/month per 25 users
+sso_pricing: $549/month per 25 users
+percent_increase: 67%
+vendor_url: https://www.testmo.com
+pricing_source: https://www.testmo.com/pricing/
+updated_at: 2026-04-13
+vendor_note: SSO and two-factor authentication require the Enterprise plan.


### PR DESCRIPTION
## Summary
- Adds Testmo to the SSO wall of shame
- SSO and two-factor authentication require upgrading from the Business plan ($329/month per 25 users) to the Enterprise plan ($549/month per 25 users) — a 67% price increase
- Pricing source: https://www.testmo.com/pricing/