### PR TITLE
Remove StatusGator

### DIFF
--- a/_vendors/statusgator.yaml
+++ b/_vendors/statusgator.yaml
@@ -1,8 +1,0 @@
----
-base_pricing: $149 per month
-name: Status Gator
-percent_increase: 436%
-pricing_source: https://statusgator.com/plans
-sso_pricing: $799 per month
-updated_at: 2025-08-23
-vendor_url: https://statusgator.com


### PR DESCRIPTION
Hello, I'm the founder of StatusGator which is listed here in the wall of shame. I'd like to request removal of StatusGator since we allow SSO on all plans and have since May 2025. Before that, it was only on multi-user plans.

SSO is a core security feature and not something we feature gate.