### PR TITLE
Delete cubecoders.yaml

### DIFF
--- a/_vendors/cubecoders.yaml
+++ b/_vendors/cubecoders.yaml
@@ -1,9 +1,0 @@
----
-name: CubeCoders
-base_pricing: $10 (Lifetime)
-sso_pricing: $40 (Lifetime)
-percent_increase: 300%
-vendor_url: https://cubecoders.com
-pricing_source: https://cubecoders.com/AMP
-updated_at: 2026-02-25
-vendor_note: SSO requires the Advanced Edition, which bundles other features. The $10 Edition (Starter) is only available if you click a tiny link under the Advanced Edition


### PR DESCRIPTION
As discussed below, the tiers mentioned are not for business use. We even included SSO as a feature in most personal tiers aside from the lowest which is for very small personal use on one computer (Think someone just wanting an easy Minecraft server for their kids without having to manually set it all up).

https://github.com/robchahin/sso-wall-of-shame/pull/668#issuecomment-4463667009

I appreciate what you're doing with the list, but it's damaging to some companies that don't warrant it.