### PR TITLE
Add vendor Graylog

### DIFF
--- a/_vendors/graylog.yaml
+++ b/_vendors/graylog.yaml
@@ -1,0 +1,13 @@
+---
+name: Graylog
+base_pricing: $1 per year
+sso_pricing: $15000 per year
+percent_increase: 1499900.0%
+vendor_url: https://graylog.org
+pricing_source: https://graylog.org/pricing/
+updated_at: 2026-05-18
+vendor_note: |
+  SSO requires the Enterprise edition and license which you can get for free until you
+  ingest more than 2GB traffic/day. Then the license goes straight to $15000 per year an
+  this is self hosted. The free license used to be 10GB/day, then went down to 5GB/day
+  and is now at 2GB/day. For a small company 10GB/day would be more than enough.


### PR DESCRIPTION
I think Graylog is an edge case.

Their lowest tier that you can buy is $15000 so as this websites calculates it, there isn't any free tier.
However they have an open-core community edition without SSO and they give you a free Enterprise license which used to give you 10GB/day log traffic and then got gradually reduced down to 2GB/day.

We tried to ask them for a more reasonable license as going from 0 to 15000 was way too steep for us however they said there is not such thing.