### PR TITLE
fix: use case-insensitive ordering for vendors

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Some vendors exploit this. They offer competitive starter plans and  gate SSO be
 
 This pricing strategy punishes growing businesses and encourages dangerous security shortcuts. If a company claims to "take your security seriously," SSO should be included in all plans or available for a reasonable charge.
 
-{% assign all = site.vendors | sort: "name" %}
+{% assign all = site.vendors | sort_natural: "name" %}
 {% assign vendors = "" | split: ',' %}
 {% assign call_us = "" | split: ',' %}
 {% for vendor in all %}


### PR DESCRIPTION
Currently vendors are sorted using case-sensitive sorting making it easy to overlook those that start with a lowercase letter since you didn't find `n8n` for instance under N as expected.

<img width="987" height="278" alt="grafik" src="https://github.com/user-attachments/assets/8fbac18e-1261-4b16-94b5-277b301ec3dc" />

This PR fixes that by swapping out the `sort` filter for `sort_natural` which according to [the docs](https://shopify.github.io/liquid/filters/sort_natural/) sorts in case-insensitive order.