### PR TITLE
Add PlanetScale

### DIFF
--- a/_vendors/planetscale.yml
+++ b/_vendors/planetscale.yml
@@ -1,0 +1,9 @@
+---
+base_pricing: $15/mo for HA
+vendor_note: SSO is an addon
+name: PlanetScale
+percent_increase: 1426%
+pricing_source: https://planetscale.com/docs/planetscale-plans#single-sign-on-sso
+sso_pricing: $199/mo Addon
+updated_at: 2026-06-21
+vendor_url: https://planetscale.com


### PR DESCRIPTION
**What is the vendor's name?**
PlanetScale

**What is the vendor's pricing site?**
https://planetscale.com/pricing + https://planetscale.com/docs/planetscale-plans#single-sign-on-sso

**What is the base pricing? Use the lowest tier that looks sane for a small business customer, not free or personal tiers.**
$15/mo for HA (there is a $5 tier, but their docs seem to refer to the $15 one as base)

**What is the minimum pricing for SSO support?**
$199 addon on top of existing pricing

**Does this pricing info come from a quote or other non-public source?**
Not listed on the regular pricing page, but is within their docs

**Are there any caveats we should add as a vendor note?**
Seems to apply at an org level, not per db