### PR TITLE
Add vendor - Visitly

### DIFF
--- a/_vendors/visitly.yaml
+++ b/_vendors/visitly.yaml
@@ -1,0 +1,9 @@
+---
+base_pricing: $899 per location/year
+name: Visitly
+pricing_source: https://www.visitly.io/pricing/
+pricing_source_info: Enterprise pricing was provided in quote from account manager
+sso_pricing: Call Us!
+updated_at: 2026-06-24
+vendor_note: Quoted $2000/location/year for SSO by account manager
+vendor_url: https://www.visitly.io


### PR DESCRIPTION
SSO is not publicly priced (Call Us!); account manager quoted $2000/location/year vs. $899/location/year base.