### PR TITLE
Add Termius

### DIFF
--- a/_vendors/termius.yaml
+++ b/_vendors/termius.yaml
@@ -1,0 +1,12 @@
+---
+name: Termius
+base_pricing: $20 per u/m
+sso_pricing: $50 per u/m
+percent_increase: 150%
+vendor_url: https://termius.com
+pricing_source:
+  - https://termius.com/pricing
+  - https://docs.termius.com/administration/saml-sso
+updated_at: 2026-07-30
+vendor_note: SAML SSO is a paid add-on to the Business plan and is not included in any published tier. The price appears only in the in-app upgrade checkout, not on the pricing page. The add-on is a flat $2,400 per year regardless of seat count, on top of Business at $30 per user/month, so the markup falls as the team grows. Figures shown are for 10 seats billed yearly ($3,600 Business plus $2,400 SSO). At 5 seats the same add-on works out to $70 per user/month, a 250% increase. Base pricing is the Team plan; the $10 Pro plan is single-user only.
+pricing_source_info: SSO add-on price is not published; taken from the in-app Business upgrade checkout at 5 and 10 seats billed yearly

--- a/_vendors/termius.yaml
+++ b/_vendors/termius.yaml
@@ -8,5 +8,5 @@ pricing_source:
   - https://termius.com/pricing
   - https://docs.termius.com/administration/saml-sso
 updated_at: 2026-07-30
-vendor_note: SAML SSO is a paid add-on to the Business plan and is not included in any published tier. The price appears only in the in-app upgrade checkout, not on the pricing page. The add-on is a flat $2,400 per year regardless of seat count, on top of Business at $30 per user/month, so the markup falls as the team grows. Figures shown are for 10 seats billed yearly ($3,600 Business plus $2,400 SSO). At 5 seats the same add-on works out to $70 per user/month, a 250% increase. Base pricing is the Team plan; the $10 Pro plan is single-user only.
-pricing_source_info: SSO add-on price is not published; taken from the in-app Business upgrade checkout at 5 and 10 seats billed yearly
+vendor_note: SAML SSO is a paid add-on to the Business plan and is not included in any published tier. The price appears only in the in-app upgrade checkout, not on the pricing page. The add-on is a flat $2,400 per year regardless of seat count, on top of Business at $30 per user/month. Figures shown are for 10 seats billed yearly ($3,600 Business plus $2,400 SSO). Because the add-on is flat, the markup falls as the team grows, from $70 per user/month at 5 seats (250%) down to $32 at 100 seats (60%). Base pricing is the Team plan; the $10 Pro plan is single-user only.
+pricing_source_info: SSO add-on price is not published; taken from the in-app Business upgrade checkout, billed yearly


### PR DESCRIPTION
Adds Termius, closes #703.

Termius sells SAML SSO as a paid add-on to its Business plan. The price is not published on the pricing page or in the docs, and appears only in the in-app upgrade checkout.

Public pricing verified against https://termius.com/pricing on 2026-07-30:

- Starter: free
- Pro: $10/month, single user
- Team: $20/user/month
- Business: $30/user/month, SAML SSO listed only under "Available add-ons"
- Enterprise: custom pricing, SAML SSO included

https://docs.termius.com/administration/saml-sso confirms SSO is Business-plan-only and add-on-gated.

Add-on price, from the in-app Business upgrade checkout on my own Team account (screenshots below, at 5, 10 and 100 seats), billed yearly:

| Seats | Business | SAML SSO | Total/yr | Per user/mo | vs $20 Team |
|---|---|---|---|---|---|
| 5 | $1,800 | $2,400 | $4,200 | $70 | 250% |
| 10 | $3,600 | $2,400 | $6,000 | $50 | 150% |
| 100 | $36,000 | $2,400 | $38,400 | $32 | 60% |

The add-on is a flat $2,400/year and does not move with seat count. Verified at 5, 10 and 100 seats: the subscription line scales twentyfold while the SAML SSO line never changes. At 5 seats the SSO add-on costs more than the product it secures.

Because it's flat, the markup is regressive: 250% for a 5-person team, 150% at 10, dropping to 60% at 100. The teams least able to absorb it pay the highest multiple. I've used the 10-seat figures for the table entry as the more conservative number, since the FAQ suggests assuming a team of 5, 10, or more.

This corrects #703, which reported the add-on as $200/user/month and arrived at $230/user/month. The $200 is the flat monthly total, not a per-user rate.

Base pricing is Team ($20) rather than Business ($30). Team is sold as a multi-seat plan ("For small teams looking for a single source of truth"), so it's the lowest tier sane for a small business team per the FAQ.

Validator: 0 errors, 0 warnings.

<img width="416" height="209" alt="image" src="https://github.com/user-attachments/assets/7fd50fba-372d-43e6-aec6-c52b6aa6d887" />
<img width="413" height="205" alt="image" src="https://github.com/user-attachments/assets/e207e1bc-7259-4d85-b5a5-a7270c69ba17" />
<img width="415" height="205" alt="image" src="https://github.com/user-attachments/assets/f984213f-65d8-4cf0-818a-2b6ab468fc1c" />
<img width="514" height="281" alt="image" src="https://github.com/user-attachments/assets/7625b4ce-9c4b-4003-9e00-912335cadbf5" />
