### PR TITLE
Add LeavePro

### DIFF
--- a/_vendors/leavepro.yaml
+++ b/_vendors/leavepro.yaml
@@ -6,5 +6,5 @@ percent_increase: 60%
 vendor_url: https://www.leavepro.co.za
 pricing_source:
   - https://www.leavepro.co.za/pricing/
-updated_at: 2026-07-30
+updated_at: 2026-08-25
 vendor_note: Single sign-on requires the Plus plan, which also bundles SMS notifications, custom branding, bulk leave applications, block dates and several other features. Prices are per employee per month in South African rand excluding VAT, roughly $1.55 and $2.50 at R16 to the dollar. LeavePro supports Microsoft 365 and Google Workspace login as well as SAML.

--- a/_vendors/leavepro.yaml
+++ b/_vendors/leavepro.yaml
@@ -1,0 +1,10 @@
+---
+name: LeavePro
+base_pricing: 25 ZAR per u/m
+sso_pricing: 40 ZAR per u/m
+percent_increase: 60%
+vendor_url: https://www.leavepro.co.za
+pricing_source:
+  - https://www.leavepro.co.za/pricing/
+updated_at: 2026-07-30
+vendor_note: Single sign-on requires the Plus plan, which also bundles SMS notifications, custom branding, bulk leave applications, block dates and several other features. Prices are per employee per month in South African rand excluding VAT, roughly $1.55 and $2.50 at R16 to the dollar. LeavePro supports Microsoft 365 and Google Workspace login as well as SAML.


### PR DESCRIPTION
Adds LeavePro, a South African leave management SaaS.

Single sign-on is only available on the Plus plan. Both prices are published on https://www.leavepro.co.za/pricing/ and verified on 2026-08-25:

| Plan | Price | SSO |
|---|---|---|
| Standard | R25 / employee / month (excl VAT) | No |
| Plus | R40 / employee / month (excl VAT) | Yes |

That's a 60% increase. Prices are in South African rand; at roughly R16 to the dollar that's about $1.55 and $2.50 per employee/month.

The pricing page lists the feature as letting staff sign in with their existing Office 365 or Google Workspace account, and notes it is "Compatible with SAML based SSO".

Plus is a genuine feature bundle rather than a pure SSO gate, so I've noted the other things it includes (SMS notifications, custom branding, bulk leave applications, block dates, sick leave abuse reporting) in the vendor_note. Happy to drop this if a 60% markup on a bundled tier is below the bar for the list.

Validator: 0 errors, 0 warnings.